### PR TITLE
Add option to put local wiki in read-only mode

### DIFF
--- a/SpecialManageWiki.php
+++ b/SpecialManageWiki.php
@@ -120,6 +120,12 @@ class SpecialManageWiki extends SpecialPage {
 				'disabled' => ( !$this->getUser()->isAllowed( 'managewiki-restricted' ) ),
 				'default' => $wiki->isPrivate() ? 1 : 0,
 			),
+			'read-only' => array(
+				'type' => 'check',
+				'label-message' => 'managewiki-label-readonly',
+				'name' => 'cw-Readonly',
+				'default' => $wiki->isReadonly() ? 1: 0,
+			),
 			'reason' => array(
 				'label-message' => 'managewiki-label-reason',
 				'type' => 'text',


### PR DESCRIPTION
Extension:ProtectSite only allows this for up to a week - this would allow it for longer (and perhaps indefinitely if needed)