### PR TITLE
You do not have permission message

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,6 +4,7 @@
 			"Southparkfan"
 		]
 	},
+	"action-managewiki": "modify wiki settings",
 	"logentry-farmer-managewiki": "$1 changed the settings for \"$4\"",
 	"managewiki": "Manage a wiki",
 	"managewiki-desc": "Allows people to manage wikis through a web interface",


### PR DESCRIPTION
You do not have permission to ⧼action-managewiki⧽, for the following reason:

The action you have requested is limited to users in one of the groups: Stewards, Wiki Creators.