### PR TITLE
fix delete group logentry

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -11,7 +11,7 @@
 	"action-managewiki": "manage wiki settings",
 	"log-description-managewiki": "This log tracks all changes to a wikis settings through ManageWiki.",
 	"log-name-managewiki": "ManageWiki log",
-	"logentry-managewiki-delete": "$1 deleted group $3",
+	"logentry-managewiki-delete-group": "$1 deleted group $3",
 	"logentry-managewiki-rename": "$1 renamed group $3 from $4",
 	"logentry-managewiki-rights": "$1 changed group metadata for $3: add rights $4; removed rights $5; added addgroups $6; removed addgroups $7; added removegroups $8; removed removegroups $9",
 	"logentry-managewiki-settings": "$1 changed the settings ($5) for \"$4\"",

--- a/includes/SpecialManageWikiPermissions.php
+++ b/includes/SpecialManageWikiPermissions.php
@@ -529,10 +529,10 @@ class SpecialManageWikiPermissions extends SpecialPage {
 	}
 
 	function addDeletionLog( $group, $reason ) {
-		$log = new LogPage('managewiki' );
+		$log = new LogPage( 'managewiki' );
 
 		$log->addEntry(
-			'delete group',
+			'delete-group',
 			SpecialPage::getTitleFor( 'ListUsers', $group ),
 			$reason
 		);


### PR DESCRIPTION
"delete" is reserved in LogEntry for regular MediaWiki deletion logs.