### PR TITLE
Fix deleting namespace by using where condition

### DIFF
--- a/includes/formFactory/ManageWikiFormFactory.php
+++ b/includes/formFactory/ManageWikiFormFactory.php
@@ -481,7 +481,7 @@ class ManageWikiFormFactory {
 							'ns_namespace_name' => $build[$name]['ns_namespace_name']
 						],
 						[
-							'ns_namespace_id' => $build[$name]['ns_namespace_id'],
+							'ns_namespace_id' => $build[$name]['ns_namespace_id']
 						],
 						__METHOD__
 					);
@@ -502,6 +502,9 @@ class ManageWikiFormFactory {
 							$build[$name],
 							[
 								'ns_dbname' => $build[$name]['ns_dbname'],
+								'ns_namespace_id' => $build[$name]['ns_namespace_id']
+							],
+							[
 								'ns_namespace_id' => $build[$name]['ns_namespace_id']
 							],
 							__METHOD__

--- a/includes/formFactory/ManageWikiFormFactory.php
+++ b/includes/formFactory/ManageWikiFormFactory.php
@@ -504,9 +504,6 @@ class ManageWikiFormFactory {
 								'ns_dbname' => $build[$name]['ns_dbname'],
 								'ns_namespace_id' => $build[$name]['ns_namespace_id']
 							],
-							[
-								'ns_namespace_id' => $build[$name]['ns_namespace_id']
-							],
 							__METHOD__
 						);
 

--- a/includes/formFactory/ManageWikiFormFactory.php
+++ b/includes/formFactory/ManageWikiFormFactory.php
@@ -143,7 +143,7 @@ class ManageWikiFormFactory {
 						'type' => 'text',
 						'label-message' => "namespaces-$name",
 						'default' => ( $nsData ) ? $nsData->ns_namespace_name : NULL,
-						'disabled' => ( !$ceMW || ( $nsData && (bool)$nsData->ns_core ) ),
+						'disabled' => ( ( $nsData && (bool)$nsData->ns_core ) || !$ceMW ),
 						'required' => true,
 						'section' => "$name"
 					],
@@ -479,6 +479,9 @@ class ManageWikiFormFactory {
 						[
 							'ns_dbname' => $build[$name]['ns_dbname'],
 							'ns_namespace_name' => $build[$name]['ns_namespace_name']
+						],
+						[
+							'ns_namespace_id' => $build[$name]['ns_namespace_id'],
 						],
 						__METHOD__
 					);


### PR DESCRIPTION
This fixes it so that it deletes only the correct namespace.