### PR TITLE
only check perms on install

### DIFF
--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -976,9 +976,9 @@ class ManageWikiFormFactoryBuilder {
 		$changedExtensions = [];
 
 		foreach ( $wgManageWikiExtensions as $name => $ext ) {
-			$requiresMet = ManageWikiRequirements::process( $dbName, $ext['requires'], $context, $formData );
-			$value = $formData["ext-$name"];
 			$current = $wiki->hasExtension( $name );
+			$requiresMet = ManageWikiRequirements::process( $dbName, $ext['requires'], $context, $formData, $current );
+			$value = $formData["ext-$name"];
 
 			if ( $ext['conflicts'] && $value && $formData["ext-{$ext['conflicts']}"] ) {
 				$errors[] = "Conflict with {$ext['conflicts']}. The extension $name can not be enabled until this is disabled.";

--- a/includes/helpers/ManageWikiRequirements.php
+++ b/includes/helpers/ManageWikiRequirements.php
@@ -1,12 +1,12 @@
 <?php
 
 class ManageWikiRequirements {
-	public static function process( string $dbname, array $actions, IContextSource $context, array $formData = [] ) {
+	public static function process( string $dbname, array $actions, IContextSource $context, array $formData = [], bool $ignorePerms = false ) {
 		// Produces an array of steps and results (so we can fail what we can't do but apply what works)
 		$stepResponse = [];
 
 		foreach ( $actions as $action => $data ) {
-			if ( $action == 'permissions' ) {
+			if ( $action == 'permissions' && !$ignorePerms ) {
 				$stepResponse['permissions'] = self::permissions( $data, $context );
 			} elseif ( $action == 'extensions' ) {
 				$stepResponse['extensions'] = self::extensions( $dbname, $data, $formData );


### PR DESCRIPTION
feels like a hack, but just adding a parameter to ManageWikiRequirements::process to ignore the permissions check seems like a decent temporary solution, barring a rewrite