### PR TITLE
Support an empty content model

### DIFF
--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -387,7 +387,7 @@ class ManageWikiFormFactoryBuilder {
 					'default' => ( $nsData ) ? $nsData->ns_content_model : 'wikitext',
 					'options' => array_merge( [
 						'CSS' => 'css',
-						'None' => '',
+						'Extension Default' => '',
 						'JavaScript' => 'javascript',
 						'JSON' => 'json',
 						'Wikitext' => 'wikitext'

--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -387,6 +387,7 @@ class ManageWikiFormFactoryBuilder {
 					'default' => ( $nsData ) ? $nsData->ns_content_model : 'wikitext',
 					'options' => array_merge( [
 						'CSS' => 'css',
+						'None' => '',
 						'JavaScript' => 'javascript',
 						'JSON' => 'json',
 						'Wikitext' => 'wikitext'


### PR DESCRIPTION
Sometimes the content model is managed by the extension it's self so no need for us to manage it.

Fixes T4699