### PR TITLE
Fix ManageWikiRequirements::extensions

### DIFF
--- a/includes/helpers/ManageWikiRequirements.php
+++ b/includes/helpers/ManageWikiRequirements.php
@@ -57,7 +57,7 @@ class ManageWikiRequirements {
 	 */
 	private static function extensions( array $data, array $extensionList ) {
 		foreach ( $data as $extension ) {
-			if ( isset( $extensionList[$extension] ) ) {
+			if ( is_array( $extensionList ) && !in_array( $extension, $extensionList ) ) {
 				return false;
 			}
 		}

--- a/includes/helpers/ManageWikiRequirements.php
+++ b/includes/helpers/ManageWikiRequirements.php
@@ -57,7 +57,7 @@ class ManageWikiRequirements {
 	 */
 	private static function extensions( array $data, array $extensionList ) {
 		foreach ( $data as $extension ) {
-			if ( is_array( $extensionList ) && !in_array( $extension, $extensionList ) ) {
+			if ( !in_array( $extension, $extensionList ) ) {
 				return false;
 			}
 		}


### PR DESCRIPTION
This fixes an issue where 'required' extensions were being ignored.

E.g you could enable wikibaseclient even though wikibaserepository was required.

Bug: T5596