### PR TITLE
Fix error return in submissionCore

### DIFF
--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -923,7 +923,7 @@ class ManageWikiFormFactoryBuilder {
 		return [
 			'changes' => implode( ', ', $changedArray ),
 			'data' => $data,
-			'errors' => false,
+			'errors' => [],
 			'log' => 'settings',
 			'table' => 'cw_wikis'
 		];


### PR DESCRIPTION
Change false to [].

Currently it will fail to call ->errors if it is false:

> $test = [ 'errors' => false, ];

> var_dump($test->errors);
PHP Notice:  Trying to get property 'errors' of non-object in /srv/mediawiki/w/maintenance/eval.php(78) : eval()'d code on line 1

Notice: Trying to get property 'errors' of non-object in /srv/mediawiki/w/maintenance/eval.php(78) : eval()'d code on line 1
NULL