### PR TITLE
Fix getting errors in submissionHandler

### DIFF
--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -799,7 +799,7 @@ class ManageWikiFormFactoryBuilder {
 		$mwLogID = $mwLogEntry->insert();
 		$mwLogEntry->publish( $mwLogID );
 
-		return $mwReturn->errors;
+		return $mwReturn['errors'];
 	}
 
 	private static function submissionCore(

--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -799,7 +799,7 @@ class ManageWikiFormFactoryBuilder {
 		$mwLogID = $mwLogEntry->insert();
 		$mwLogEntry->publish( $mwLogID );
 
-		return $mwReturn['errors'];
+		return is_array( $mwReturn ) ? $mwReturn['errors'] : $mwReturn->errors;
 	}
 
 	private static function submissionCore(


### PR DESCRIPTION
Add check so that if $mwReturn returns an array,
call errors by doing '$mwReturn['errors']' and if it is an object
then call it with '$mwReturn->errors'.

```
> $test = [ 'errors' => false, ];

> var_dump($test->errors);
PHP Notice:  Trying to get property 'errors' of non-object in /srv/mediawiki/w/maintenance/eval.php(78) : eval()'d code on line 1

Notice: Trying to get property 'errors' of non-object in /srv/mediawiki/w/maintenance/eval.php(78) : eval()'d code on line 1
NULL
```

log:

```
/wiki/Speciale:ManageWiki/core   ErrorException from line 802 of /srv/mediawiki/w/extensions/ManageWiki/includes/formFactory/ManageWikiFormFactoryBuilder.php: PHP Notice: Trying to get property 'errors' of non-object
```