### PR TITLE
Fix ::onCreateWikiStatePrivate

### DIFF
--- a/includes/ManageWikiHooks.php
+++ b/includes/ManageWikiHooks.php
@@ -241,7 +241,7 @@ class ManageWikiHooks {
 			}
 
 			$mwPermissions->modify( $wgManageWikiPermissionsDefaultPrivateGroup, $privateArray );
-			$mwPermissions->modify( 'sysop', [ 'addgroups' => [ 'add' => $wgManageWikiPermissionsDefaultPrivateGroup ], 'removegroups' => [ 'add' => $wgManageWikiPermissionsDefaultPrivateGroup ] ] );
+			$mwPermissions->modify( 'sysop', [ 'addgroups' => [ 'add' => [ $wgManageWikiPermissionsDefaultPrivateGroup ] ], 'removegroups' => [ 'add' => [ $wgManageWikiPermissionsDefaultPrivateGroup ] ] ] );
 			$mwPermissions->commit();
 		}
 	}


### PR DESCRIPTION
Changes addgroup/removegroup value to be an array.

Example:

```
> $permData = [ 'addgroups' => [] ];

> $test = array_merge( $permData['addgroups'], 'test' );
PHP Warning:  array_merge(): Expected parameter 2 to be an array, string given in /srv/mediawiki/w/maintenance/eval.php(78) : eval()'d code on line 1

Warning: array_merge(): Expected parameter 2 to be an array, string given in /srv/mediawiki/w/maintenance/eval.php(78) : eval()'d code on line 1

> var_dump($test);
NULL
```

Bug: T5660