### PR TITLE
Fix addgroups/removegroups becomming null in the db

### DIFF
--- a/includes/ManageWikiHooks.php
+++ b/includes/ManageWikiHooks.php
@@ -255,7 +255,7 @@ class ManageWikiHooks {
 			$mwPermissions->remove( $wgManageWikiPermissionsDefaultPrivateGroup );
 
 			foreach ( array_keys( $mwPermissions->list() ) as $group ) {
-				$mwPermissions->modify( $group, [ 'addgroups' => [ 'remove' => $wgManageWikiPermissionsDefaultPrivateGroup ], 'removegroups' => [ 'remove' => $wgManageWikiPermissionsDefaultPrivateGroup ] ] );
+				$mwPermissions->modify( $group, [ 'addgroups' => [ 'remove' => [ $wgManageWikiPermissionsDefaultPrivateGroup ] ], 'removegroups' => [ 'remove' => [ $wgManageWikiPermissionsDefaultPrivateGroup ] ] ] );
 			}
 
 			$mwPermissions->commit();


### PR DESCRIPTION
Fixes an issue when switching from private to public.

Bug: T5697