### PR TITLE
travis: drop php7.2 test and explicitly state os

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 dist: bionic
+os: linux
 
 php:
   - 7.4
   - 7.3
-  - 7.2
 
 addons:
   sonarcloud:


### PR DESCRIPTION
PHP7.2 is dropped in REL1_35

OS parameter should be stated, fixes a build info thing. Similar PR should probably done on all php repos.