### PR TITLE
ManageWikiPopulateSettings: Fix args

### DIFF
--- a/maintenance/populateWikiSettings.php
+++ b/maintenance/populateWikiSettings.php
@@ -9,8 +9,8 @@ require_once "$IP/maintenance/Maintenance.php";
 class ManageWikiPopulateSettings extends Maintenance {
 	public function __construct() {
 		parent::__construct();
-		$this->addOption( 'wgsetting', 'The $wg setting minus $.' );
-		$this->addOption( 'sourcelist', 'File in format of "wiki|value" for the $wg setting above.' );
+		$this->addOption( 'wgsetting', 'The $wg setting minus $.', true, true );
+		$this->addOption( 'sourcelist', 'File in format of "wiki|value" for the $wg setting above.', true, true );
 	}
 
 	public function execute() {


### PR DESCRIPTION
These should be required and also should be known as args.

This fixes it so you can do --wgsetting <setting> rather than forced to do --wgsetting=<setting>