### PR TITLE
Add float and skins types to ManageWiki

### DIFF
--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -337,6 +337,26 @@ class ManageWikiFormFactoryBuilder {
 							$configs['dropdown'] = true;
 						}
 						break;
+					case 'skins':
+  						$enabledSkins = MediaWikiServices::getInstance()->getSkinFactory()->getSkinNames();
+						
+						unset( $enabledSkins['fallback'] );
+						unset( $enabledSkins['apioutput'] );
+						
+						foreach ( $config->get( 'SkipSkins' ) as $skip ) {
+							unset( $enabledSkins[$skip] );
+						}
+						
+						foreach ( $enabledSkins as $skin => $skinName ){
+							$availableSkins[$skinName] = $skin;
+						}
+						
+						$configs = [
+							'type' => 'select',
+							'options' => isset( $set['options'] ) ? array_merge( $availableSkins, $set['options'] ) : $availableSkins,
+							'default' => $setList[$name] ?? $set['overridedefault']
+						];
+						break;
 					case 'timezone':
 						$configs = [
 							'type' => 'select',

--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -323,37 +323,19 @@ class ManageWikiFormFactoryBuilder {
 							'default' => $setList[$name] ?? $set['overridedefault']
 						];
 						break;
-					case 'preferences':
-						$preferences = [];
-						foreach( MediaWikiServices::getInstance()->getUserOptionsLookup()->getOptions( $context->getUser() ) as $preference => $val ) {
-							$preferences[$preference] = $preference;
-						}
-						$configs = [
-							'type' => 'multiselect',
-							'options' => isset( $set['options'] ) ? array_merge( $preferences, $set['options'] ) : $preferences,
-							'default' => $setList[$name] ?? $set['overridedefault']
-						];
-						if ( !$disabled ) {
-							$configs['dropdown'] = true;
-						}
-						break;
 					case 'skins':
   						$enabledSkins = MediaWikiServices::getInstance()->getSkinFactory()->getSkinNames();
-						
+
 						unset( $enabledSkins['fallback'] );
 						unset( $enabledSkins['apioutput'] );
-						
+
 						foreach ( $config->get( 'SkipSkins' ) as $skip ) {
 							unset( $enabledSkins[$skip] );
 						}
 						
-						foreach ( $enabledSkins as $skin => $skinName ){
-							$availableSkins[$skinName] = $skin;
-						}
-						
 						$configs = [
 							'type' => 'select',
-							'options' => isset( $set['options'] ) ? array_merge( $availableSkins, $set['options'] ) : $availableSkins,
+							'options' => isset( $set['options'] ) ? array_merge( array_flip($enabledSkins), $set['options'] ) : array_flip($enabledSkins),
 							'default' => $setList[$name] ?? $set['overridedefault']
 						];
 						break;

--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -254,6 +254,14 @@ class ManageWikiFormFactoryBuilder {
 							$configs['options'][$db] = $db;
 						}
 						break;
+					case 'float':
+						$configs = [
+							'type' => 'float',
+							'min' => $set['minfloat'],
+							'max' => $set['maxfloat'],
+							'default' => $setList[$name] ?? $set['overridedefault']
+						];
+						break;
 					case 'integer':
 						$configs = [
 							'type' => 'int',
@@ -314,6 +322,20 @@ class ManageWikiFormFactoryBuilder {
 							'type' => 'namespacesmultiselect',
 							'default' => $setList[$name] ?? $set['overridedefault']
 						];
+						break;
+					case 'preferences':
+						$preferences = [];
+						foreach( MediaWikiServices::getInstance()->getUserOptionsLookup()->getOptions( $context->getUser() ) as $preference => $val ) {
+							$preferences[$preference] = $preference;
+						}
+						$configs = [
+							'type' => 'multiselect',
+							'options' => isset( $set['options'] ) ? array_merge( $preferences, $set['options'] ) : $preferences,
+							'default' => $setList[$name] ?? $set['overridedefault']
+						];
+						if ( !$disabled ) {
+							$configs['dropdown'] = true;
+						}
 						break;
 					case 'timezone':
 						$configs = [


### PR DESCRIPTION
* `float` type would be useful for configs that need it; nothing in particular
* `skins` type would be useful to improve upon the method used with `$wgDefaultSkins` to support `$wgSkipSkins` as well as prevent us from having to add `$wgManageWikiSettings['wgDefaultSkin']['options']['DISPLAYNAME'] = 'SKINNAME';` for every skin,
