### PR TITLE
use array on array for return on managewiki-changes-none

### DIFF
--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -978,7 +978,7 @@ class ManageWikiFormFactoryBuilder {
 		if ( $mwReturn->changes ) {
 			$mwReturn->commit();
 		} else {
-			return [ 'managewiki-changes-none' => [] ];
+			return [ [ 'managewiki-changes-none' => null ] ];
 		}
 
 		if ( $module != 'permissions' ) {

--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -978,7 +978,7 @@ class ManageWikiFormFactoryBuilder {
 		if ( $mwReturn->changes ) {
 			$mwReturn->commit();
 		} else {
-			return [ 'managewiki-changes-none' => null ];
+			return [ 'managewiki-changes-none' => [] ];
 		}
 
 		if ( $module != 'permissions' ) {


### PR DESCRIPTION
Because if it is null then https://github.com/miraheze/ManageWiki/blob/02bd453558b3ee687c7b2066fa364897411aca21/includes/formFactory/ManageWikiFormFactory.php#L72 would return invalid argument for foreach()