### PR TITLE
DefaultPermissions: fix broken message tag

### DIFF
--- a/includes/specials/SpecialManageWikiDefaultPermissions.php
+++ b/includes/specials/SpecialManageWikiDefaultPermissions.php
@@ -50,7 +50,7 @@ class SpecialManageWikiDefaultPermissions extends SpecialPage {
  		if ( $permissionManager->userHasRight( $this->getContext()->getUser(), 'managewiki-editdefault' ) ) {
 			$createDescriptor['groups'] = [
 				'type' => 'text',
-				'label-message' => 'managewiki-permissions-creategroup',
+				'label-message' => 'managewiki-permissions-create',
 				'validation-callback' => [ $this, 'validateNewGroupName' ],
 			];
 


### PR DESCRIPTION
Spotted it today while checking something.

Looks like it should just be 'create' not 'creategoup' or at least that's what Special:ManageWiki does