### PR TITLE
Multiple improvements to ManageWikiNamespaces

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -141,11 +141,6 @@
 				"media"
 			]
 		},
-		"ManageWikiNamespacesExtraContentModels": {
-			"description": "Array. Additional content models not known.",
-			"public": true,
-			"value": false
-		},
 		"ManageWikiSettings": {
 			"description": "Array. An array of settings that can be managed through Special:ManageWiki",
 			"public": true,

--- a/includes/ManageWikiHooks.php
+++ b/includes/ManageWikiHooks.php
@@ -94,8 +94,10 @@ class ManageWikiHooks {
 				$nsAdditional = json_decode( $ns->ns_additional, true );
 
 				foreach ( (array)$nsAdditional as $var => $val ) {
-					if ( $val && isset( self::getConfig( 'ManageWikiNamespacesAdditional' )[$var] ) ) {
-						switch ( self::getConfig( 'ManageWikiNamespacesAdditional' )[$var]['type'] ) {
+					$additional = self::getConfig( 'ManageWikiNamespacesAdditional' );
+
+					if ( $val && isset( $additional[$var] ) ) {
+						switch ( $additional[$var]['type'] ) {
 							case 'check':
 								$jsonArray['settings'][$var][] = (int)$ns->ns_namespace_id;
 								break;
@@ -103,7 +105,11 @@ class ManageWikiHooks {
 								$jsonArray['settings'][$var][(int)$ns->ns_namespace_id] = true;
 								break;
 							default:
-								$jsonArray['settings'][$var][(int)$ns->ns_namespace_id] = $val;
+								if ( ( $additional[$var]['constant'] ) ?? false ) {
+									$jsonArray['settings'][$var] = str_replace( ' ', '_', $val );
+								} else {
+									$jsonArray['settings'][$var][(int)$ns->ns_namespace_id] = $val;
+								}
 						}
 					}
 				}

--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -260,7 +260,7 @@ class ManageWikiFormFactoryBuilder {
 			$msgHelp = wfMessage( "managewiki-setting-{$name}-help" );
 
 			if ( $add ) {
-				$configs = ManageWikiTypes::process( $config, $disabled, 'settings', $set, $setList[$name] ?? null, $groupList );
+				$configs = ManageWikiTypes::process( $config, $disabled, $groupList, 'settings', $set, $setList[$name] ?? null );
 
 				$help = ( $msgHelp->exists() ) ? $msgHelp->text() : $set['help'];
 				if ( $set['requires'] ) {
@@ -408,7 +408,7 @@ class ManageWikiFormFactoryBuilder {
 						$a['overridedefault'] = $a['overridedefault'][$id] ?? $a['overridedefault']['default'];
 					}
 
-					$configs = ManageWikiTypes::process( $config, ( $ceMW ) ? !$mwRequirements : true, 'namespaces', $a, $namespaceData['additional'][$key] ?? null );
+					$configs = ManageWikiTypes::process( false, false, false, 'namespaces', false, $namespaceData['additional'][$key] ?? null, $a['overridedefault'], $a['type'] );
 
 					$formDescriptor["$key-$name"] = [
 						'label' => $a['name'] . " (\${$key})",

--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -320,7 +320,7 @@ class ManageWikiFormFactoryBuilder {
 			$formDescriptor += [
 				"namespace-$name" => [
 					'type' => 'text',
-					'label-message' => "namespaces-$name",
+					'label' => wfMessage( "namespaces-$name" )->text() . ' ($wgExtraNamespaces)',
 					'default' => $namespaceData['name'],
 					'disabled' => ( $namespaceData['core'] || !$ceMW ),
 					'required' => true,
@@ -328,33 +328,33 @@ class ManageWikiFormFactoryBuilder {
 				],
 				"content-$name" => [
 					'type' => 'check',
-					'label-message' => 'namespaces-content',
+					'label' => wfMessage( 'namespaces-content' )->text() . ' ($wgContentNamespaces)',
 					'default' => $namespaceData['content'],
 					'disabled' => !$ceMW,
 					'section' => $name
 				],
 				"subpages-$name" => [
 					'type' => 'check',
-					'label-message' => 'namespaces-subpages',
+					'label' => wfMessage( 'namespaces-subpages' )->text() . ' ($wgNamespacesWithSubpages)',
 					'default' => $namespaceData['subpages'],
 					'disabled' => !$ceMW,
 					'section' => $name
 				],
 				"search-$name" => [
 					'type' => 'check',
-					'label-message' => 'namespaces-search',
+					'label' => wfMessage( 'namespaces-search' )->text() . ' ($wgNamespacesToBeSearchedDefault)',
 					'default' => $namespaceData['searchable'],
 					'disabled' => !$ceMW,
 					'section' => $name
 				],
 				"contentmodel-$name" => [
-					'label-message' => 'namespaces-contentmodel',
+					'label' => wfMessage( 'namespaces-contentmodel' )->text() . ' ($wgNamespaceContentModels)',
 					'cssclass' => 'createwiki-infuse',
 					'section' => $name
 				] + ManageWikiTypes::process( false, !$ceMW, false, 'namespaces', false, $namespaceData['contentmodel'], false, 'contentmodel' ),
 				"protection-$name" => [
 					'type' => 'combobox',
-					'label-message' => 'namespaces-protection',
+					'label' => wfMessage( 'namespaces-protection' )->text() . ' ($wgNamespaceProtection)',
 					'cssclass' => 'createwiki-infuse',
 					'default' => $namespaceData['protection'],
 					'options' => [
@@ -412,7 +412,7 @@ class ManageWikiFormFactoryBuilder {
 
 			$formDescriptor["aliases-$name"] = [
 				'type' => 'textarea',
-				'label-message' => 'namespaces-aliases',
+				'label' => wfMessage( 'namespaces-aliases' )->text() . ' ($wgNamespaceAliases)',
 				'default' => implode( "\n", $namespaceData['aliases'] ),
 				'disabled' => !$ceMW,
 				'section' => $name

--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -253,7 +253,6 @@ class ManageWikiFormFactoryBuilder {
 			$mwRequirements = $set['requires'] ? ManageWikiRequirements::process( $set['requires'], $extList, false, $wiki ) : true;
 
 			$add = ( isset( $set['requires']['visibility'] ) ? $mwRequirements : true ) && ( ( $set['from'] == 'mediawiki' ) || ( in_array( $set['from'], $extList ) ) );
-
 			$disabled = ( $ceMW ) ? !$mwRequirements : true;
 			
 			$msgName = wfMessage( "managewiki-setting-{$name}-name" );
@@ -372,10 +371,15 @@ class ManageWikiFormFactoryBuilder {
 				$mwRequirements = $a['requires'] ? ManageWikiRequirements::process( $a['requires'], $extList, false, $wiki ) : true;
 
 				$add = ( isset( $a['requires']['visibility'] ) ? $mwRequirements : true ) && ( ( $a['from'] == 'mediawiki' ) || ( in_array( $a['from'], $extList ) ) );
+				$disabled = ( $ceMW ) ? !$mwRequirements : true;
+
+				$msgName = wfMessage( "managewiki-namespaces-{$key}-name" );
+				$msgHelp = wfMessage( "managewiki-namespaces-{$key}-help" );
 
 				if ( $add && ( $a['main'] && $name == 'namespace' || $a['talk'] && $name == 'namespacetalk' ) && ( !in_array( $id, (array)$a['blacklisted'] ) ) ) {
-					$help = $a['help'];
+					$configs = ManageWikiTypes::process( $config, $disabled, false, 'namespaces', $a, $namespaceData['additional'][$key] ?? null, $a['overridedefault'], $a['type'] );
 
+					$help = ( $msgHelp->exists() ) ? $msgHelp->text() : $a['help'];
 					if ( $a['requires'] ) {
 						$requires = [];
 						$requiresLabel = wfMessage( 'managewiki-requires' )->text();
@@ -399,11 +403,8 @@ class ManageWikiFormFactoryBuilder {
 						$a['overridedefault'] = $a['overridedefault'][$id] ?? $a['overridedefault']['default'];
 					}
 
-					$disabled = ( $ceMW ) ? !$mwRequirements : true;
-					$configs = ManageWikiTypes::process( $config, $disabled, false, 'namespaces', $a, $namespaceData['additional'][$key] ?? null, $a['overridedefault'], $a['type'] );
-
 					$formDescriptor["$key-$name"] = [
-						'label' => $a['name'] . " (\${$key})",
+						'label' => ( ( $msgName->exists() ) ? $msgName->text() : $a['name'] ) . " (\${$key})",
 						'help' => $help,
 						'section' => $name
 					] + $configs;

--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -408,11 +408,11 @@ class ManageWikiFormFactoryBuilder {
 						$a['overridedefault'] = $a['overridedefault'][$id] ?? $a['overridedefault']['default'];
 					}
 
-					$configs = ManageWikiTypes::process( false, false, false, 'namespaces', false, $namespaceData['additional'][$key] ?? null, $a['overridedefault'], $a['type'] );
+					$disabled = ( $ceMW ) ? !$mwRequirements : true;
+					$configs = ManageWikiTypes::process( $config, $disabled, false, 'namespaces', $a, $namespaceData['additional'][$key] ?? null, $a['overridedefault'], $a['type'] );
 
 					$formDescriptor["$key-$name"] = [
 						'label' => $a['name'] . " (\${$key})",
-						'disabled' => ( $ceMW ) ? !$mwRequirements : true,
 						'help' => $help,
 						'section' => $name
 					] + $configs;

--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -348,21 +348,12 @@ class ManageWikiFormFactoryBuilder {
 					'section' => $name
 				],
 				"contentmodel-$name" => [
-					'type' => 'select',
 					'label-message' => 'namespaces-contentmodel',
 					'cssclass' => 'createwiki-infuse',
-					'default' => $namespaceData['contentmodel'],
-					'options' => array_merge( [
-						'CSS' => 'css',
-						'JavaScript' => 'javascript',
-						'JSON' => 'json',
-						'Wikitext' => 'wikitext'
-						], (array)$config->get( 'ManageWikiNamespacesExtraContentModels' ) ),
-					'disabled' => !$ceMW,
 					'section' => $name
-				],
+				] + ManageWikiTypes::process( false, !$ceMW, false, 'namespaces', false, $namespaceData['contentmodel'], false, 'contentmodel' ),
 				"protection-$name" => [
-					'type' => 'selectorother',
+					'type' => 'combobox',
 					'label-message' => 'namespaces-protection',
 					'cssclass' => 'createwiki-infuse',
 					'default' => $namespaceData['protection'],
@@ -403,7 +394,7 @@ class ManageWikiFormFactoryBuilder {
 
 						$help .= "<br />{$requiresLabel}: " . implode( ' & ', $requires );
 					}
-					
+
 					if ( is_array( $a['overridedefault'] ) ) {
 						$a['overridedefault'] = $a['overridedefault'][$id] ?? $a['overridedefault']['default'];
 					}

--- a/includes/helpers/ManageWikiTypes.php
+++ b/includes/helpers/ManageWikiTypes.php
@@ -331,8 +331,10 @@ class ManageWikiTypes {
 					continue;
 				}
 
-				$contentModels[ContentHandler::getLocalizedName( $model )] = $model;
+				$contentModels[ucfirst( ContentHandler::getLocalizedName( $model ) )] = $model;
 			}
+
+			uksort( $contentModels, 'strcasecmp' );
 
 			$configs = [
 				'type' => 'select',

--- a/includes/helpers/ManageWikiTypes.php
+++ b/includes/helpers/ManageWikiTypes.php
@@ -3,7 +3,7 @@
 use MediaWiki\MediaWikiServices;
 
 class ManageWikiTypes {
-	public static function process( $config, $disabled, $groupList, $module, $options, $value, $type = false, $overrideDefault = false ) {
+	public static function process( $config, $disabled, $groupList, $module, $options, $value, $overrideDefault = false, $type = false ) {
 		if ( $module === 'namespaces' ) {
 			return self::namespaces( $overrideDefault, $type, $value ) ?: self::common( $config, $disabled, $options, $value, $groupList );
 		}

--- a/includes/helpers/ManageWikiTypes.php
+++ b/includes/helpers/ManageWikiTypes.php
@@ -5,7 +5,7 @@ use MediaWiki\MediaWikiServices;
 class ManageWikiTypes {
 	public static function process( $config, $disabled, $groupList, $module, $options, $value, $overrideDefault = false, $type = false ) {
 		if ( $module === 'namespaces' ) {
-			return self::namespaces( $overrideDefault, $type, $value ) ?: self::common( $config, $disabled, $options, $value, $groupList );
+			return self::namespaces( $disabled, $overrideDefault, $type, $value ) ?: self::common( $config, $disabled, $options, $value, $groupList );
 		}
 
 		return self::common( $config, $disabled, $options, $value, $groupList );		
@@ -317,7 +317,7 @@ class ManageWikiTypes {
 		return $configs;
 	}
 
-	private static function namespaces( $overrideDefault, $type, $value ) {
+	private static function namespaces( $disabled, $overrideDefault, $type, $value ) {
 		$configs = [];
 
 		if ( $type === 'contentmodel' ) {
@@ -337,12 +337,14 @@ class ManageWikiTypes {
 			$configs = [
 				'type' => 'select',
 				'options' => $contentModels,
-				'default' => $value
+				'default' => $value,
+				'disabled' => $disabled
 			];
 		} elseif ( $type === 'vestyle' ) {
 			$configs = [
 				'type' => 'check',
-				'default' => $value ?? $overridedDefault
+				'default' => $value ?? $overrideDefault,
+				'disabled' => $disabled
 			];
 		}
 


### PR DESCRIPTION
* Add new `contentmodel` type to use for the ManageWikiNamespaces `contentmodel` field, instead of the `$wgManageWikiNamespacesExtraContentModels` config.
  * Remove `$wgManageWikiNamespacesExtraContentModels` from `extension.json`.
* Use `combobox` type instead of `selectorother`, for the ManageWikiNamespaces `protection` field, since this is cleaner.
* Add config variables to ManageWikiNamespaces labels.
* Add support to ManageWikiNamespacesAdditional, for localised labels and help messages.
* Add support for constant namespace-related configs to be added to ManageWikiNamespaces, such as configs that don't just effect one namespace, or that are not part of an array of namespaces.
  * Should add support for `$wgMetaNamespace` and `$wgMetaNamespaceTalk`. `'blacklisted'` would be used to only make these able to be changed from `NS_PROJECT(_TALK)`.
    * ```php
      'blacklisted' => array_diff( array_keys( $wgExtraNamespaces ), [ NS_PROJECT(_TALK) ] )
### Also, unrelated to ManageWikiNamespaces:
* Rename the `databases` type to `database`, since it is for only selecting **one** database.
* Cleanup ManageWikiTypes class.