### PR TITLE
Blacklist downloaduserdata from preferences form type

### DIFF
--- a/includes/helpers/ManageWikiTypes.php
+++ b/includes/helpers/ManageWikiTypes.php
@@ -187,15 +187,18 @@ class ManageWikiTypes {
 					}
 				}
 
-				// Never show searchNs* prefs
+				// Blacklist searchNs* prefs
 				foreach( preg_grep( '/searchNs[0-9]/', array_keys( $allPreferences ) ) as $pref => $value ) {
 					$excludedPrefs[] = array_keys( $allPreferences )[$pref];
 				}
 
-				// Blacklist echo-subscriptions preferences
+				// Blacklist echo-subscriptions-* preferences
 				foreach( preg_grep( '/echo-subscriptions-(?s).*/', array_keys( $allPreferences ) ) as $pref => $value ) {
 					$excludedPrefs[] = array_keys( $allPreferences )[$pref];
 				}
+
+				// Blacklist downloaduserdata preference
+				$excludedPrefs[] = 'downloaduserdata';
 
 				foreach( $allPreferences as $preference => $val ) {
 					if ( !in_array( $preference, $excludedPrefs ) ) {

--- a/includes/helpers/ManageWikiTypes.php
+++ b/includes/helpers/ManageWikiTypes.php
@@ -187,7 +187,7 @@ class ManageWikiTypes {
 					}
 				}
 
-				// Blacklist searchNs* prefs
+				// Blacklist searchNs* preferences
 				foreach( preg_grep( '/searchNs[0-9]/', array_keys( $allPreferences ) ) as $pref => $value ) {
 					$excludedPrefs[] = array_keys( $allPreferences )[$pref];
 				}


### PR DESCRIPTION
downloaduserdata is available since 1.35.2, it should never be hidden with wgHiddenPrefs, as users should always be able to see/use it.