### PR TITLE
[BUG FIX] fix preferences type

### DIFF
--- a/includes/helpers/ManageWikiTypes.php
+++ b/includes/helpers/ManageWikiTypes.php
@@ -200,9 +200,9 @@ class ManageWikiTypes {
 				// Blacklist downloaduserdata preference
 				$excludedPrefs[] = 'downloaduserdata';
 
-				foreach( $allPreferences as $preference => $val ) {
-					if ( !in_array( $preference, $excludedPrefs ) ) {
-						$preferences[$preference] = $preference;
+				foreach( $allPreferences as $pref => $val ) {
+					if ( !in_array( $pref, $excludedPrefs ) ) {
+						$preferences[$pref] = $pref;
 					}
 				}
 

--- a/includes/helpers/ManageWikiTypes.php
+++ b/includes/helpers/ManageWikiTypes.php
@@ -131,7 +131,7 @@ class ManageWikiTypes {
 				if( $config->get( 'DisableLangConversion' ) ) {
 					$excludedPrefs[] = 'variant';
 				} else {
-					foreach( preg_grep( '/variant-[A-Za-z0-9]/', array_keys( $allPreferences ) ) as $pref => $value ) {
+					foreach( preg_grep( '/variant-[A-Za-z0-9]/', array_keys( $allPreferences ) ) as $pref => $val ) {
 						$excludedPrefs[] = array_keys( $allPreferences )[$pref];
 					}
 				}
@@ -188,12 +188,12 @@ class ManageWikiTypes {
 				}
 
 				// Blacklist searchNs* preferences
-				foreach( preg_grep( '/searchNs[0-9]/', array_keys( $allPreferences ) ) as $pref => $value ) {
+				foreach( preg_grep( '/searchNs[0-9]/', array_keys( $allPreferences ) ) as $pref => $val ) {
 					$excludedPrefs[] = array_keys( $allPreferences )[$pref];
 				}
 
 				// Blacklist echo-subscriptions-* preferences
-				foreach( preg_grep( '/echo-subscriptions-(?s).*/', array_keys( $allPreferences ) ) as $pref => $value ) {
+				foreach( preg_grep( '/echo-subscriptions-(?s).*/', array_keys( $allPreferences ) ) as $pref => $val ) {
 					$excludedPrefs[] = array_keys( $allPreferences )[$pref];
 				}
 


### PR DESCRIPTION
This prevents the `foreach` `=> $value` from overwriting the set config `$value` thus not correctly displaying config as the HTMLForm field default.