### PR TITLE
Give close confirmation if settings are changed

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -114,8 +114,16 @@
 	"ResourceModules": {
 		"ext.managewiki.oouiform": {
 			"targets": [ "desktop", "mobile" ],
-			"scripts": "ext.managewiki.oouiform.js",
+			"scripts": [
+				"ext.managewiki.oouiform.js",
+				"ext.managewiki.oouiform.confirmClose.js"
+			],
+			"messages": [
+				"managewiki-warning-changes",
+				"managewiki-save"
+			],
 			"dependencies": [
+				"mediawiki.confirmCloseWindow",
 				"mediawiki.storage",
 				"mediawiki.widgets.TitlesMultiselectWidget",
 				"oojs-ui-widgets"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -126,6 +126,7 @@
 	"managewiki-link-settings": "Manage this wiki's additional settings",
 	"managewiki-link-settings-view": "View this wiki's additional settings",
 	"managewiki-toggle-forcesidebar": "Force the display of ManageWiki links in the sidebar.",
+	"managewiki-warning-changes": "You've made changes to ManageWiki that have not been saved yet.\nIf you leave this page without clicking \"$1\" your ManageWiki changes will not be updated.",
 	"namespaces-aliases": "Enter on a new line all undefined namespaces which should redirect to this one.",
 	"namespaces-content": "Does this namespace contain main wiki material (content)?",
 	"namespaces-contentmodel": "What should this namespace's content model be?",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -69,6 +69,7 @@
 	"managewiki-save": "Text for the ManageWiki 'Save' button.\n{{Identical|Save}}",
 	"managewiki-sidebar-header": "Used as a label for the sidebar.\n{{Identical|Administration}}",
 	"managewiki-success": "Message when the wiki request was succesfully sent.",
+	"managewiki-warning-changes": "Warning shown (except in Firefox) when attempting to leave ManageWiki with unsaved changes.",
 	"namespaces-delete": "{{Identical|Delete}}",
 	"permissions-delete": "{{Identical|Delete}}",
 	"right-managewiki": "{{doc-right|managewiki}}"

--- a/includes/formFactory/ManageWikiFormFactory.php
+++ b/includes/formFactory/ManageWikiFormFactory.php
@@ -42,7 +42,9 @@ class ManageWikiFormFactory {
 
 		$htmlForm->setSubmitTextMsg( 'managewiki-save' );
 
-		$htmlForm->setId( 'mw-baseform-' . $module );
+		$htmlForm->setId( 'managewiki-form' );
+		$htmlForm->setSubmitID( 'managewiki-submit' );
+
 		$htmlForm->setSubmitCallback(
 			function ( array $formData, HTMLForm $form ) use ( $module, $ceMW, $remoteWiki, $special, $dbw, $wiki, $config ) {
 				return $this->submitForm( $formData, $form, $module, $ceMW, $wiki, $remoteWiki, $dbw, $config, $special );

--- a/includes/helpers/ManageWikiOOUIForm.php
+++ b/includes/helpers/ManageWikiOOUIForm.php
@@ -88,7 +88,6 @@ class ManageWikiOOUIForm extends OOUIHTMLForm {
 			'type' => 'text',
 			'placeholder-message' => 'managewiki-placeholder-reason',
 			'id' => 'managewiki-submit-reason',
-			'cssclass' => 'managewiki-infuse',
 			'required' => true
 		];
 

--- a/includes/helpers/ManageWikiOOUIForm.php
+++ b/includes/helpers/ManageWikiOOUIForm.php
@@ -88,6 +88,7 @@ class ManageWikiOOUIForm extends OOUIHTMLForm {
 			'type' => 'text',
 			'placeholder-message' => 'managewiki-placeholder-reason',
 			'id' => 'managewiki-submit-reason',
+			'cssclass' => 'managewiki-infuse',
 			'required' => true
 		];
 

--- a/includes/helpers/ManageWikiOOUIForm.php
+++ b/includes/helpers/ManageWikiOOUIForm.php
@@ -4,7 +4,7 @@ class ManageWikiOOUIForm extends OOUIHTMLForm {
 	protected $mSubSectionBeforeFields = false;
 
 	public function wrapForm( $html ) {
-		$html = Xml::tags( 'div', [ 'id' => 'baseform' ], $html );
+		$html = Xml::tags( 'div', [ 'id' => 'managewiki' ], $html );
 
 		return parent::wrapForm( $html );
 	}
@@ -12,7 +12,7 @@ class ManageWikiOOUIForm extends OOUIHTMLForm {
 	protected function wrapFieldSetSection( $legend, $section, $attributes, $isRoot ) {
 		$layout = parent::wrapFieldSetSection( $legend, $section, $attributes, $isRoot );
 
-		$layout->addClasses( [ 'mw-managewiki-fieldset-wrapper' ] );
+		$layout->addClasses( [ 'managewiki-fieldset-wrapper' ] );
 		$layout->removeClasses( [ 'oo-ui-panelLayout-framed' ] );
 
 		return $layout;
@@ -42,7 +42,7 @@ class ManageWikiOOUIForm extends OOUIHTMLForm {
 				'classes' => [ 'mw-htmlform-autoinfuse-lazy' ],
 				'label' => $label,
 				'content' => new OOUI\FieldsetLayout( [
-					'classes' => [ 'mw-managewiki-section-fieldset' ],
+					'classes' => [ 'managewiki-section-fieldset' ],
 					'id' => "mw-section-{$key}",
 					'label' => $label,
 					'items' => [
@@ -60,7 +60,7 @@ class ManageWikiOOUIForm extends OOUIHTMLForm {
 			'infusable' => true,
 			'expanded' => false,
 			'autoFocus' => false,
-			'classes' => [ 'mw-managewiki-tabs' ],
+			'classes' => [ 'managewiki-tabs' ],
 		] );
 
 		$indexLayout->addTabPanels( $tabPanels );
@@ -70,7 +70,7 @@ class ManageWikiOOUIForm extends OOUIHTMLForm {
 		$form = new OOUI\PanelLayout( [
 			'framed' => true,
 			'expanded' => false,
-			'classes' => [ 'mw-managewiki-tabs-wrapper' ],
+			'classes' => [ 'managewiki-tabs-wrapper' ],
 			'content' => $indexLayout
 		] );
 

--- a/includes/helpers/ManageWikiOOUIForm.php
+++ b/includes/helpers/ManageWikiOOUIForm.php
@@ -87,6 +87,7 @@ class ManageWikiOOUIForm extends OOUIHTMLForm {
 		$descriptor['reason'] = [
 			'type' => 'text',
 			'placeholder-message' => 'managewiki-placeholder-reason',
+			'id' => 'managewiki-submit-reason',
 			'required' => true
 		];
 

--- a/includes/specials/SpecialManageWiki.php
+++ b/includes/specials/SpecialManageWiki.php
@@ -83,15 +83,18 @@ class SpecialManageWiki extends SpecialPage {
 	public function showWikiForm( $wiki, $module, $special ) {
 		$out = $this->getOutput();
 
-		if ( !$special ) {
+		if ( $special ) {
 			$out->addModules( [ 'ext.managewiki.oouiform' ] );
+
 			$out->addModuleStyles( [
 				'ext.managewiki.oouiform.styles',
 				'mediawiki.widgets.TagMultiselectWidget.styles',
 			] );
 
 			$out->addModuleStyles( 'oojs-ui-widgets.styles' );
+		}
 
+		if ( !$special ) {
 			$out->addWikiMsg( "managewiki-header-{$module}", $wiki );
 		}
 

--- a/includes/specials/SpecialManageWiki.php
+++ b/includes/specials/SpecialManageWiki.php
@@ -83,14 +83,15 @@ class SpecialManageWiki extends SpecialPage {
 	public function showWikiForm( $wiki, $module, $special ) {
 		$out = $this->getOutput();
 
-		$out->addModules( [ 'ext.managewiki.oouiform' ] );
-		$out->addModuleStyles( [
-			'ext.managewiki.oouiform.styles',
-			'mediawiki.widgets.TagMultiselectWidget.styles',
-		] );
-		$out->addModuleStyles( 'oojs-ui-widgets.styles' );
-
 		if ( !$special ) {
+			$out->addModules( [ 'ext.managewiki.oouiform' ] );
+			$out->addModuleStyles( [
+				'ext.managewiki.oouiform.styles',
+				'mediawiki.widgets.TagMultiselectWidget.styles',
+			] );
+
+			$out->addModuleStyles( 'oojs-ui-widgets.styles' );
+
 			$out->addWikiMsg( "managewiki-header-{$module}", $wiki );
 		}
 

--- a/includes/specials/SpecialManageWiki.php
+++ b/includes/specials/SpecialManageWiki.php
@@ -83,7 +83,7 @@ class SpecialManageWiki extends SpecialPage {
 	public function showWikiForm( $wiki, $module, $special ) {
 		$out = $this->getOutput();
 
-		if ( $special ) {
+		if ( $special || $module === 'core' ) {
 			$out->addModules( [ 'ext.managewiki.oouiform' ] );
 
 			$out->addModuleStyles( [

--- a/includes/specials/SpecialManageWiki.php
+++ b/includes/specials/SpecialManageWiki.php
@@ -83,7 +83,7 @@ class SpecialManageWiki extends SpecialPage {
 	public function showWikiForm( $wiki, $module, $special ) {
 		$out = $this->getOutput();
 
-		if ( $special || in_array( $module, [ 'core', 'extensions', 'settings' ] ) ) {
+		if ( $special !== '' || in_array( $module, [ 'core', 'extensions', 'settings' ] ) ) {
 			$out->addModules( [ 'ext.managewiki.oouiform' ] );
 
 			$out->addModuleStyles( [

--- a/includes/specials/SpecialManageWiki.php
+++ b/includes/specials/SpecialManageWiki.php
@@ -83,7 +83,7 @@ class SpecialManageWiki extends SpecialPage {
 	public function showWikiForm( $wiki, $module, $special ) {
 		$out = $this->getOutput();
 
-		if ( $special || $module === 'core' ) {
+		if ( $special || in_array( $module, [ 'core', 'extensions', 'settings' ] ) ) {
 			$out->addModules( [ 'ext.managewiki.oouiform' ] );
 
 			$out->addModuleStyles( [

--- a/modules/ext.managewiki.oouiform.confirmClose.js
+++ b/modules/ext.managewiki.oouiform.confirmClose.js
@@ -4,13 +4,13 @@
  */
 ( function () {
 	$( function () {
-		var allowCloseWindow, saveButton;
+		var allowCloseWindow, reasonField, saveButton;
 
 		// Check if all of the form values are unchanged.
 		// (This function could be changed to infuse and check OOUI widgets, but that would only make it
 		// slower and more complicated. It works fine to treat them as HTML elements.)
 		function isManageWikiChanged() {
-			var $inputs = $( '#managewiki-form :input[name]' ),
+			var $inputs = $( '#managewiki-form :input[name]:not( #managewiki-submit-reason )' ),
 				input, $input, inputType,
 				index, optIndex,
 				opt;
@@ -44,11 +44,13 @@
 			return false;
 		}
 
+		reasonField = OO.ui.infuse( $( '#managewiki-submit-reason' ) );
 		saveButton = OO.ui.infuse( $( '#managewiki-submit' ) );
 
 		// Disable the button to save unless settings have changed
 		// Check if settings have been changed before JS has finished loading
 		saveButton.setDisabled( !isManageWikiChanged() );
+		reasonField.setDisabled( !isManageWikiChanged() );
 		// Attach capturing event handlers to the document, to catch events inside OOUI dropdowns:
 		// * Use capture because OO.ui.SelectWidget also does, and it stops event propagation,
 		//   so the event is not fired on descendant elements
@@ -59,6 +61,7 @@
 				// Make sure SelectWidget's event handlers run first
 				setTimeout( function () {
 					saveButton.setDisabled( !isManageWikiChanged() );
+					reasonField.setDisabled( !isManageWikiChanged() );
 				} );
 			}, true );
 		} );

--- a/modules/ext.managewiki.oouiform.confirmClose.js
+++ b/modules/ext.managewiki.oouiform.confirmClose.js
@@ -1,0 +1,74 @@
+/*!
+ * JavaScript for Special:ManageWiki: Enable save button and prevent the window being accidentally
+ * closed when any form field is changed.
+ */
+( function () {
+	$( function () {
+		var allowCloseWindow, saveButton;
+
+		// Check if all of the form values are unchanged.
+		// (This function could be changed to infuse and check OOUI widgets, but that would only make it
+		// slower and more complicated. It works fine to treat them as HTML elements.)
+		function isManageWikiChanged() {
+			var $inputs = $( '#managewiki-form :input[name]' ),
+				input, $input, inputType,
+				index, optIndex,
+				opt;
+
+			for ( index = 0; index < $inputs.length; index++ ) {
+				input = $inputs[ index ];
+				$input = $( input );
+
+				// Different types of inputs have different methods for accessing defaults
+				if ( $input.is( 'select' ) ) {
+					// <select> has the property defaultSelected for each option
+					for ( optIndex = 0; optIndex < input.options.length; optIndex++ ) {
+						opt = input.options[ optIndex ];
+						if ( opt.selected !== opt.defaultSelected ) {
+							return true;
+						}
+					}
+				} else if ( $input.is( 'input' ) || $input.is( 'textarea' ) ) {
+					// <input> has defaultValue or defaultChecked
+					inputType = input.type;
+					if ( inputType === 'radio' || inputType === 'checkbox' ) {
+						if ( input.checked !== input.defaultChecked ) {
+							return true;
+						}
+					} else if ( input.value !== input.defaultValue ) {
+						return true;
+					}
+				}
+			}
+
+			return false;
+		}
+
+		saveButton = OO.ui.infuse( $( '#managewiki-submit' ) );
+
+		// Disable the button to save unless settings have changed
+		// Check if settings have been changed before JS has finished loading
+		saveButton.setDisabled( !isManageWikiChanged() );
+		// Attach capturing event handlers to the document, to catch events inside OOUI dropdowns:
+		// * Use capture because OO.ui.SelectWidget also does, and it stops event propagation,
+		//   so the event is not fired on descendant elements
+		// * Attach to the document because the dropdowns are in the .oo-ui-defaultOverlay element
+		//   (and it doesn't exist yet at this point, so we can't attach them to it)
+		[ 'change', 'keyup', 'mouseup' ].forEach( function ( eventType ) {
+			document.addEventListener( eventType, function () {
+				// Make sure SelectWidget's event handlers run first
+				setTimeout( function () {
+					saveButton.setDisabled( !isManageWikiChanged() );
+				} );
+			}, true );
+		} );
+
+		// Set up a message to notify users if they try to leave the page without
+		// saving.
+		allowCloseWindow = mw.confirmCloseWindow( {
+			test: isManageWikiChanged,
+			message: mw.msg( 'managewiki-warning-changes', mw.msg( 'managewiki-save' ) )
+		} );
+		$( '#managewiki-form' ).on( 'submit', allowCloseWindow.release );
+	} );
+}() );

--- a/modules/ext.managewiki.oouiform.confirmClose.js
+++ b/modules/ext.managewiki.oouiform.confirmClose.js
@@ -10,7 +10,7 @@
 		// (This function could be changed to infuse and check OOUI widgets, but that would only make it
 		// slower and more complicated. It works fine to treat them as HTML elements.)
 		function isManageWikiChanged() {
-			var $inputs = $( '#managewiki-form :input[name]:not( #managewiki-submit-reason )' ),
+			var $inputs = $( '#managewiki-form :input[name]:not( #managewiki-submit-reason :input[name] )' ),
 				input, $input, inputType,
 				index, optIndex,
 				opt;

--- a/modules/ext.managewiki.oouiform.confirmClose.js
+++ b/modules/ext.managewiki.oouiform.confirmClose.js
@@ -44,7 +44,7 @@
 			return false;
 		}
 
-		reasonField = OO.ui.infuse( $( '#managewiki-submit-reason' ) );
+		reasonField = $( '#managewiki-submit-reason' );
 		saveButton = OO.ui.infuse( $( '#managewiki-submit' ) );
 
 		// Disable the button to save unless settings have changed

--- a/modules/ext.managewiki.oouiform.confirmClose.js
+++ b/modules/ext.managewiki.oouiform.confirmClose.js
@@ -4,7 +4,7 @@
  */
 ( function () {
 	$( function () {
-		var allowCloseWindow, reasonField, saveButton;
+		var allowCloseWindow, saveButton;
 
 		// Check if all of the form values are unchanged.
 		// (This function could be changed to infuse and check OOUI widgets, but that would only make it
@@ -44,13 +44,11 @@
 			return false;
 		}
 
-		reasonField = $( '#managewiki-submit-reason' );
 		saveButton = OO.ui.infuse( $( '#managewiki-submit' ) );
 
 		// Disable the button to save unless settings have changed
 		// Check if settings have been changed before JS has finished loading
 		saveButton.setDisabled( !isManageWikiChanged() );
-		reasonField.setDisabled( !isManageWikiChanged() );
 		// Attach capturing event handlers to the document, to catch events inside OOUI dropdowns:
 		// * Use capture because OO.ui.SelectWidget also does, and it stops event propagation,
 		//   so the event is not fired on descendant elements
@@ -61,7 +59,6 @@
 				// Make sure SelectWidget's event handlers run first
 				setTimeout( function () {
 					saveButton.setDisabled( !isManageWikiChanged() );
-					reasonField.setDisabled( !isManageWikiChanged() );
 				} );
 			}, true );
 		} );

--- a/modules/ext.managewiki.oouiform.js
+++ b/modules/ext.managewiki.oouiform.js
@@ -7,7 +7,7 @@
 		tabs.$element.addClass( 'managewiki-tabs-infused' );
 
 		function enhancePanel( panel ) {
-			infuse = $( panel.$element ).find( '.managewiki-infuse' );
+			var infuse = $( panel.$element ).find( '.managewiki-infuse' );
 			infuse.each( function () {
 				OO.ui.infuse( this );
 			} );
@@ -22,9 +22,6 @@
 		function onTabPanelSet( panel ) {
 			var scrollTop, active;
 
-			if ( switchingNoHash ) {
-				return;
-			}
 			// Handle hash manually to prevent jumping,
 			// therefore save and restore scrollTop to prevent jumping.
 			scrollTop = $( window ).scrollTop();

--- a/modules/ext.managewiki.oouiform.js
+++ b/modules/ext.managewiki.oouiform.js
@@ -63,13 +63,13 @@
 			var hash = location.hash,
 				matchedElement, $parentSection;
 			if ( hash.match( /^#mw-section-[\w]+$/ ) ) {
-				mw.storage.session.remove( 'mwmanagewiki-prevTab' );
+				mw.storage.session.remove( 'managewiki-prevTab' );
 				switchManageWikiTab( hash.slice( 1 ) );
 			} else if ( hash.match( /^#mw-[\w-]+$/ ) ) {
 				matchedElement = document.getElementById( hash.slice( 1 ) );
-				$parentSection = $( matchedElement ).closest( '.mw-managewiki-section-fieldset' );
+				$parentSection = $( matchedElement ).closest( '.managewiki-section-fieldset' );
 				if ( $parentSection.length ) {
-					mw.storage.session.remove( 'mwmanagewiki-prevTab' );
+					mw.storage.session.remove( 'managewiki-prevTab' );
 					// Switch to proper tab and scroll to selected item.
 					switchManageWikiTab( $parentSection.attr( 'id' ), true );
 					matchedElement.scrollIntoView();
@@ -87,16 +87,16 @@
 			.trigger( 'hashchange' );
 
 		// Restore the active tab after saving the settings
-		previousTab = mw.storage.session.get( 'mwmanagewiki-prevTab' );
+		previousTab = mw.storage.session.get( 'managewiki-prevTab' );
 		if ( previousTab ) {
 			switchManageWikiTab( previousTab, true );
 			// Deleting the key, the tab states should be reset until we press Save
-			mw.storage.session.remove( 'mwmanagewiki-prevTab' );
+			mw.storage.session.remove( 'managewiki-prevTab' );
 		}
 
-		$( "[id*=\"mw-baseform-\"]" ).on( 'submit', function () {
+		$( "#managewiki-form" ).on( 'submit', function () {
 			var value = tabs.getCurrentTabPanelName();
-			mw.storage.session.set( 'mwmanagewiki-prevTab', value );
+			mw.storage.session.set( 'managewiki-prevTab', value );
 		} );
 	} );
 }() );

--- a/modules/ext.managewiki.oouiform.js
+++ b/modules/ext.managewiki.oouiform.js
@@ -1,17 +1,17 @@
 ( function () {
 	$( function () {
 		var tabs, previousTab, switchingNoHash;
-
-		infuse = $( '.oo-ui-menuLayout-content' ).find( '[data-ooui*="managewiki-infuse"], .managewiki-infuse[name]' );
-		infuse.each( function () {
-			OO.ui.infuse( this );
-		} );
 		
 		tabs = OO.ui.infuse( $( '.managewiki-tabs' ) );
 
 		tabs.$element.addClass( 'managewiki-tabs-infused' );
 
 		function enhancePanel( panel ) {
+			infuse = $( panel.$element ).find( '.managewiki-infuse[name]' );
+			infuse.each( function () {
+				OO.ui.infuse( this );
+			} );
+
 			if ( !panel.$element.data( 'mw-section-infused' ) ) {
 				panel.$element.removeClass( 'mw-htmlform-autoinfuse-lazy' );
 				mw.hook( 'htmlform.enhance' ).fire( panel.$element );
@@ -81,6 +81,8 @@
 			var hash = location.hash;
 			if ( hash.match( /^#mw-[\w-]+/ ) ) {
 				detectHash();
+			} else if ( hash === '' ) {
+				switchManageWikiTab( $( '[id*=mw-section-]' ).attr( 'id' ), true );
 			}
 		} )
 			// Run the function immediately to select the proper tab on startup.

--- a/modules/ext.managewiki.oouiform.js
+++ b/modules/ext.managewiki.oouiform.js
@@ -7,9 +7,9 @@
 			OO.ui.infuse( this );
 		} );
 		
-		tabs = OO.ui.infuse( $( '.mw-managewiki-tabs' ) );
+		tabs = OO.ui.infuse( $( '.managewiki-tabs' ) );
 
-		tabs.$element.addClass( 'mw-managewiki-tabs-infused' );
+		tabs.$element.addClass( 'managewiki-tabs-infused' );
 
 		function enhancePanel( panel ) {
 			if ( !panel.$element.data( 'mw-section-infused' ) ) {

--- a/modules/ext.managewiki.oouiform.js
+++ b/modules/ext.managewiki.oouiform.js
@@ -22,6 +22,9 @@
 		function onTabPanelSet( panel ) {
 			var scrollTop, active;
 
+			if ( switchingNoHash ) {
+				return;
+			}
 			// Handle hash manually to prevent jumping,
 			// therefore save and restore scrollTop to prevent jumping.
 			scrollTop = $( window ).scrollTop();

--- a/modules/ext.managewiki.oouiform.js
+++ b/modules/ext.managewiki.oouiform.js
@@ -62,7 +62,7 @@
 		function detectHash() {
 			var hash = location.hash,
 				matchedElement, $parentSection;
-			if ( hash.match( /^#mw-section-[\w]+$/ ) ) {
+			if ( hash.match( /^#mw-section-[\w-]+$/ ) ) {
 				mw.storage.session.remove( 'managewiki-prevTab' );
 				switchManageWikiTab( hash.slice( 1 ) );
 			} else if ( hash.match( /^#mw-[\w-]+$/ ) ) {

--- a/modules/ext.managewiki.oouiform.js
+++ b/modules/ext.managewiki.oouiform.js
@@ -7,7 +7,7 @@
 		tabs.$element.addClass( 'managewiki-tabs-infused' );
 
 		function enhancePanel( panel ) {
-			infuse = $( panel.$element ).find( '.managewiki-infuse[name]' );
+			infuse = $( panel.$element ).find( '.managewiki-infuse' );
 			infuse.each( function () {
 				OO.ui.infuse( this );
 			} );

--- a/modules/ext.managewiki.oouiform.styles.less
+++ b/modules/ext.managewiki.oouiform.styles.less
@@ -1,6 +1,6 @@
 @import 'mediawiki.mixins.less';
 
-#baseform {
+#managewiki {
 	filter: brightness( 1 );
 
 	.managewiki-submit-formfields {
@@ -21,8 +21,8 @@
 	}
 }
 
-.mw-managewiki-tabs {
-	.mw-managewiki-fieldset-wrapper {
+.managewiki-tabs {
+	.managewiki-fieldset-wrapper {
 		padding-left: 0;
 		padding-right: 0;
 
@@ -36,8 +36,8 @@
 	}
 }
 
-.mw-managewiki-tabs-wrapper.oo-ui-panelLayout-framed,
-.mw-managewiki-tabs > .oo-ui-menuLayout-content > .oo-ui-indexLayout-stackLayout > .oo-ui-tabPanelLayout {
+.managewiki-tabs-wrapper.oo-ui-panelLayout-framed,
+.managewiki-tabs > .oo-ui-menuLayout-content > .oo-ui-indexLayout-stackLayout > .oo-ui-tabPanelLayout {
 	/* Decrease contrast of `border` slightly as padding/border combination is sufficient
 	 * accessibility wise and focus of content is more important here. */
 	border-color: #c8ccd1;
@@ -46,18 +46,18 @@
 /* JavaScript disabled */
 .client-nojs {
 	// Disable .oo-ui-panelLayout-framed on outer wrapper
-	.mw-managewiki-tabs-wrapper {
+	.managewiki-tabs-wrapper {
 		border-width: 0;
 		border-radius: 0;
 	}
 
-	.mw-managewiki-tabs {
+	.managewiki-tabs {
 		// Hide the tab menu when JS is disabled as we can't use this feature
 		> .oo-ui-menuLayout-menu {
 			display: none;
 		}
 
-		.mw-managewiki-section-fieldset {
+		.managewiki-section-fieldset {
 			// <legend> is hard to style, so apply border to top of group
 			> .oo-ui-fieldsetLayout-group {
 				padding-top: 1.5em;
@@ -78,7 +78,7 @@
 }
 
 /* JavaScript enabled */
-.client-js .mw-managewiki-tabs {
+.client-js .managewiki-tabs {
 	.oo-ui-tabPanelLayout {
 		// Panels don't need borders as the IndexLayout is inside a framed wrapper.
 		border: 0;
@@ -90,7 +90,7 @@
 	}
 
 	// Hide all but the first panel before infusion
-	&:not( .mw-managewiki-tabs-infused ) {
+	&:not( .managewiki-tabs-infused ) {
 		.oo-ui-tabPanelLayout:not( :first-child ) {
 			display: none;
 		}


### PR DESCRIPTION
Also:
* Disables the save button until changes are made.

* Lazy-infuses fields, so won't infuse until you are on the tab, to further improve performance.

* Fixes a JavaScript error on ManageWiki special pages without anything to infuse (like namespaces and permissions) - it does not allow the resources to load in that case, as it's redundant to anyways.

