### PR TITLE
Merge ExtensionCredits only if given

### DIFF
--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -232,7 +232,7 @@ class ManageWikiFormFactoryBuilder {
 
 		$credits = $data['credits'];
 		$legacyCredits = $config->get( 'ExtensionCredits' );
-		if ( is_array( $legacyCredits ) && $legacyCredits ) {
+		if ( $legacyCredits ) {
 			$credits = array_merge( $credits, array_values(
 					array_merge( ...array_values( $legacyCredits ) )
 				)

--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -230,10 +230,14 @@ class ManageWikiFormFactoryBuilder {
 
 		$data = $processor->getExtractedInfo();
 
-		$credits = array_merge( $data['credits'], array_values(
-				array_merge( ...array_values( $config->get( 'ExtensionCredits' ) ) )
-			)
-		);
+		$credits = $data['credits'];
+		$legacyCredits = $config->get( 'ExtensionCredits' );
+		if ( is_array( $legacyCredits ) && $legacyCredits ) {
+			$credits = array_merge( $credits, array_values(
+					array_merge( ...array_values( $legacyCredits ) )
+				)
+			);
+		}
 
 		$formDescriptor = [];
 


### PR DESCRIPTION
[$wgExtensionCredits](https://www.mediawiki.org/wiki/Manual:$wgExtensionCredits) is deprecated and only used by some extensions already. In the future, It would be empty. This prepares the situation.