### PR TITLE
Add a new type 'integers'

### DIFF
--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -959,6 +959,11 @@ class ManageWikiFormFactoryBuilder {
 				$settingsArray[$name] = ( $mwAllowed ) ? ManageWiki::handleMatrix( $value, 'phparray' ) : ManageWiki::handleMatrix( $current, 'php' );
 			} elseif ( $type == 'check' ) {
 				$settingsArray[$name] = ( $mwAllowed ) ? $value : $current;
+			} elseif ( $type == 'integers' ) {
+				$value = array_column( $value, 'integer' );
+				$value = array_filter( $value );
+				$value = array_map( 'intval', $value );
+				$settingsArray[$name] = ( $mwAllowed ) ? $value : $current;
 			} elseif ( $type == 'list-multi' || $type == 'usergroups' || $type == 'userrights' ) {
 				$settingsArray[$name] = $value;
 			} elseif ( $type == 'list-multi-bool' ) {

--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -364,7 +364,7 @@ class ManageWikiFormFactoryBuilder {
 				}
 
 				// Hack to prevent "implicit submission". See T275588 for more
-				if ( $set['type'] === 'integers' ) {
+				if ( $configs['type'] === 'cloner' ) {
 					$formDescriptor["fake-submit-$name"] = [
 						'type' => 'submit',
 						'disabled' => true,

--- a/includes/formFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/formFactory/ManageWikiFormFactoryBuilder.php
@@ -363,6 +363,16 @@ class ManageWikiFormFactoryBuilder {
 					$help .= "<br />{$requiresLabel}: " . implode( ' & ', $requires );
 				}
 
+				// Hack to prevent "implicit submission". See T275588 for more
+				if ( $set['type'] === 'integers' ) {
+					$formDescriptor["fake-submit-$name"] = [
+						'type' => 'submit',
+						'disabled' => true,
+						'section' => $set['section'],
+						'cssclass' => 'managewiki-fakesubmit',
+					];
+				}
+
 				$formDescriptor["set-$name"] = [
 					'label' => ( ( $msgName->exists() ) ? $msgName->text() : $set['name'] ) . " (\${$name})",
 					'disabled' => $disabled,

--- a/includes/helpers/ManageWikiOOUIForm.php
+++ b/includes/helpers/ManageWikiOOUIForm.php
@@ -40,7 +40,6 @@ class ManageWikiOOUIForm extends OOUIHTMLForm {
 				$this->getFooterText( $key );
 
 			$tabPanels[] = new OOUI\TabPanelLayout( 'mw-section-' . $key, [
-				'classes' => [ 'mw-htmlform-autoinfuse-lazy' ],
 				'label' => $label,
 				'content' => new OOUI\FieldsetLayout( [
 					'classes' => [ 'managewiki-section-fieldset' ],

--- a/includes/helpers/ManageWikiOOUIForm.php
+++ b/includes/helpers/ManageWikiOOUIForm.php
@@ -40,6 +40,7 @@ class ManageWikiOOUIForm extends OOUIHTMLForm {
 				$this->getFooterText( $key );
 
 			$tabPanels[] = new OOUI\TabPanelLayout( 'mw-section-' . $key, [
+				'classes' => [ 'mw-htmlform-autoinfuse-lazy' ],
 				'label' => $label,
 				'content' => new OOUI\FieldsetLayout( [
 					'classes' => [ 'managewiki-section-fieldset' ],

--- a/includes/helpers/ManageWikiTypes.php
+++ b/includes/helpers/ManageWikiTypes.php
@@ -51,7 +51,7 @@ class ManageWikiTypes {
 						]
 					],
 					'default' => array_map( static function ( $num ) { return [ 'integer' => $num ]; },
-						( isset( $value ) && $value !== null ) ? $value : $options['overridedefault'] ),
+						$value ?? $options['overridedefault'] ),
 				];
 				break;
 			case 'interwiki':

--- a/includes/helpers/ManageWikiTypes.php
+++ b/includes/helpers/ManageWikiTypes.php
@@ -40,6 +40,20 @@ class ManageWikiTypes {
 					'default' => $value ?? $options['overridedefault']
 				];
 				break;
+			case 'integers':
+				$configs = [
+					'type' => 'cloner',
+					'fields' => [
+						'integer' => [
+							'type' => 'int',
+							'min' => $options['minint'] ?? null,
+							'max' => $options['maxint'] ?? null,
+						]
+					],
+					'default' => array_map( static function ( $num ) { return [ 'integer' => $num ]; },
+						( isset( $value ) && $value !== null ) ? $value : $options['overridedefault'] ),
+				];
+				break;
 			case 'interwiki':
 				$interwikiPrefixes = [];
 

--- a/includes/helpers/ManageWikiTypes.php
+++ b/includes/helpers/ManageWikiTypes.php
@@ -48,7 +48,12 @@ class ManageWikiTypes {
 							'type' => 'int',
 							'min' => $options['minint'] ?? null,
 							'max' => $options['maxint'] ?? null,
-						]
+						],
+						'delete' => [
+							'type' => 'submit',
+							'default' => wfMessage( 'htmlform-cloner-delete' )->escaped(),
+							'flags' => [ 'destructive' ],
+						],
 					],
 					'default' => array_map( static function ( $num ) { return [ 'integer' => $num ]; },
 						$value ?? $options['overridedefault'] ),

--- a/modules/ext.managewiki.oouiform.confirmClose.js
+++ b/modules/ext.managewiki.oouiform.confirmClose.js
@@ -16,6 +16,17 @@
 		function isManageWikiChanged() {
 			var result = false;
 
+			$( '#managewiki-form  .mw-htmlform-cloner-ul' ).each( function () {
+				if ( Number( this.dataset.initialFieldSize ) !== this.children.length ) {
+					result = true;
+
+					return false;
+				}
+			} );
+			if ( result ) {
+				return true;
+			}
+
 			$( '#managewiki-form :input[name]:not( #managewiki-submit-reason :input[name] )' ).each( function () {
 				if ( this.defaultChecked !== undefined && this.type === 'checkbox' && this.defaultChecked !== this.checked ) {
 					result = true;
@@ -30,6 +41,14 @@
 
 			return result;
 		}
+
+		// Store the initial number of children of cloners for later use, as an equivalent of
+		// defaultChecked.
+		$( '#managewiki-form .mw-htmlform-cloner-ul' ).each( function () {
+			if ( this.dataset.initialFieldSize === undefined ) {
+				this.dataset.initialFieldSize = this.children.length;
+			}
+		} );
 
 		saveButton = OO.ui.infuse( $( '#managewiki-submit' ) );
 

--- a/modules/ext.managewiki.oouiform.confirmClose.js
+++ b/modules/ext.managewiki.oouiform.confirmClose.js
@@ -43,7 +43,7 @@
 		}
 
 		// Store the initial number of children of cloners for later use, as an equivalent of
-		// defaultChecked.
+		// defaultValue.
 		$( '#managewiki-form .mw-htmlform-cloner-ul' ).each( function () {
 			if ( this.dataset.initialFieldSize === undefined ) {
 				this.dataset.initialFieldSize = this.children.length;

--- a/modules/ext.managewiki.oouiform.styles.less
+++ b/modules/ext.managewiki.oouiform.styles.less
@@ -125,3 +125,11 @@
 .oo-ui-fieldLayout-field .oo-ui-tagMultiselectWidget ~ :not( :first-child ) {
 	display: none;
 }
+
+.mw-htmlform-cloner-ul {
+	list-style: none;
+
+	> li > div {
+		display: flex;
+	}
+}

--- a/modules/ext.managewiki.oouiform.styles.less
+++ b/modules/ext.managewiki.oouiform.styles.less
@@ -133,3 +133,7 @@
 		display: flex;
 	}
 }
+
+.mw-special-ManageWiki .oo-ui-fieldLayout {
+	margin-top: 0;
+}

--- a/modules/ext.managewiki.oouiform.styles.less
+++ b/modules/ext.managewiki.oouiform.styles.less
@@ -137,3 +137,7 @@
 .mw-special-ManageWiki .oo-ui-fieldLayout {
 	margin-top: 0;
 }
+
+.mw-special-ManageWiki .managewiki-fakesubmit {
+	display: none;
+}

--- a/modules/ext.managewiki.oouiform.tabs.js
+++ b/modules/ext.managewiki.oouiform.tabs.js
@@ -15,6 +15,12 @@
 					return;
 				}
 			} );
+
+			if ( !panel.$element.data( 'mw-section-infused' ) ) {
+				panel.$element.removeClass( 'mw-htmlform-autoinfuse-lazy' );
+				mw.hook( 'htmlform.enhance' ).fire( panel.$element );
+				panel.$element.data( 'mw-section-infused', true );
+			}
 		}
 
 		function onTabPanelSet( panel ) {

--- a/modules/ext.managewiki.oouiform.tabs.js
+++ b/modules/ext.managewiki.oouiform.tabs.js
@@ -1,6 +1,8 @@
 ( function () {
 	$( function () {
-		var tabs, previousTab, switchingNoHash;
+		// The lazy loading is temporarily disabled to prevent conflict with the cloner widget.
+		var autoinfuseLazy = false,
+			tabs, previousTab, switchingNoHash;
 
 		tabs = OO.ui.infuse( $( '.managewiki-tabs' ) );
 
@@ -16,7 +18,7 @@
 				}
 			} );
 
-			if ( !panel.$element.data( 'mw-section-infused' ) ) {
+			if ( autoinfuseLazy && !panel.$element.data( 'mw-section-infused' ) ) {
 				panel.$element.removeClass( 'mw-htmlform-autoinfuse-lazy' );
 				mw.hook( 'htmlform.enhance' ).fire( panel.$element );
 				panel.$element.data( 'mw-section-infused', true );

--- a/modules/ext.managewiki.oouiform.tabs.js
+++ b/modules/ext.managewiki.oouiform.tabs.js
@@ -15,12 +15,6 @@
 					return;
 				}
 			} );
-
-			if ( !panel.$element.data( 'mw-section-infused' ) ) {
-				panel.$element.removeClass( 'mw-htmlform-autoinfuse-lazy' );
-				mw.hook( 'htmlform.enhance' ).fire( panel.$element );
-				panel.$element.data( 'mw-section-infused', true );
-			}
 		}
 
 		function onTabPanelSet( panel ) {


### PR DESCRIPTION
This adds a new type `'integers'` using [HTMLFormFieldCloner](https://github.com/wikimedia/mediawiki/blob/REL1_37/includes/htmlform/fields/HTMLFormFieldCloner.php) class. This is inspired by [Special:GlobalWatchlistSettings](https://meta.wikimedia.org/wiki/Special:GlobalWatchlistSettings)' user defined site list.

![image](https://user-images.githubusercontent.com/28209361/150641289-b876f258-8b4a-446b-b0a3-dcb62da9548d.png)

There are several following TODOs:

Bugs:

- Pushing the 'Add more' button adds two more fields.
- The review changes dialog exposes not formatted diffs. Example:
  > wgExampleIntegersConfig[1][integer] (Other) was changed from 2 to 1
  >wgExampleIntegersConfig[clone1][integer] (Other) was changed from <none> to 11
- Without javascript, HTMLFormFieldCloner's buttons act as submit button, and Special:ManageWiki does not allow to leave the submit-reason field empty. Thus, the user should fill the field with dummy text, but the text is not be restored.
- ~~Removing a field is not considered as making a change by Special:ManageWiki. A user should make a dummy change to any field before submitting.~~ &rarr; https://github.com/miraheze/ManageWiki/pull/329/commits/c07cf2aad88aa79011bc7a6b73a36991d4736508
- ~~While typing, pressing the enter key makes the first field disappears because the first Remove button is pushed. I don't know how Special:GlobalWatchlistSettings prevented it.~~ &rarr; https://github.com/miraheze/ManageWiki/pull/329/commits/54e12e1df997bbf36ab387d57a4b19f905015d2b

Note:

- I allowed omitting min or max value by using `$options['minint'] ?? null` syntax because some configs, including my motivation, wgPropertySuggesterInitialSuggestions should not have a maximum limit.
- I don't know well how ManageWiki works and I am not sure the settings are well stored by this change. The stored value looks below:
```
MariaDB [default]> select * from mw_settings;
+----------+----------------------------------------------+--------------+
| s_dbname | s_settings                                   | s_extensions |
+----------+----------------------------------------------+--------------+
| default  | {"wgExampleIntegersConfig":[1,2,30,122,-50]} | []           |
+----------+----------------------------------------------+--------------+
```