### PR TITLE
Support associative arrays in ManageWikiSettings

### DIFF
--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -395,8 +395,14 @@ class ManageWikiFormFactoryBuilder {
 					];
 				}
 
+				if ( isset( $set['associativeKey'] ) ) {
+					$varName = " (\${$name}['{$set['associativeKey']}'])";
+				} else {
+					$varName = " (\${$name})";
+				}
+
 				$formDescriptor["set-$name"] = [
-					'label' => ( ( $msgName->exists() ) ? $msgName->text() : $set['name'] ) . " (\${$name})",
+					'label' => ( ( $msgName->exists() ) ? $msgName->text() : $set['name'] ) . $varName,
 					'disabled' => $disabled,
 					'help' => $help,
 					'cssclass' => 'managewiki-infuse',
@@ -981,7 +987,12 @@ class ManageWikiFormFactoryBuilder {
 				continue;
 			}
 
-			$current = $settingsList[$name] ?? $set['overridedefault'];
+			if ( isset( $set['associativeKey'] ) ) {
+				$current = $settingsList[$name][ $set['associativeKey'] ] ?? $set['overridedefault'];
+			} else {
+				$current = $settingsList[$name] ?? $set['overridedefault'];
+			}
+
 			$mwAllowed = $set['requires'] ? ManageWikiRequirements::process( $set['requires'], $extList, false, $wiki ) : true;
 			$type = $set['type'];
 

--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -363,6 +363,10 @@ class ManageWikiFormFactoryBuilder {
 			$msgHelp = wfMessage( "managewiki-setting-{$name}-help" );
 
 			if ( $add ) {
+				if ( isset( $set['associativeKey'] ) ) {
+					$set['overridedefault'] = $set['overridedefault'][ $set['associativeKey'] ];
+				}
+
 				$configs = ManageWikiTypes::process( $config, $disabled, $groupList, 'settings', $set, $setList[$name] ?? null );
 
 				$help = ( $msgHelp->exists() ) ? $msgHelp->text() : $set['help'];
@@ -988,7 +992,7 @@ class ManageWikiFormFactoryBuilder {
 			}
 
 			if ( isset( $set['associativeKey'] ) ) {
-				$current = $settingsList[$name][ $set['associativeKey'] ] ?? $set['overridedefault'];
+				$current = $settingsList[$name][ $set['associativeKey'] ] ?? $set['overridedefault'][ $set['associativeKey'] ];
 			} else {
 				$current = $settingsList[$name] ?? $set['overridedefault'];
 			}
@@ -1034,10 +1038,7 @@ class ManageWikiFormFactoryBuilder {
 			}
 
 			if ( isset( $set['associativeKey'] ) ) {
-				if ( isset( $GLOBALS[$name] ) ) {
-					$settingsArray[$name] = $GLOBALS[$name];
-				}
-
+				$settingsArray[$name] = $set['overridedefault'];
 				$settingsArray[$name][ $set['associativeKey'] ] = $value;
 			} else {
 				$settingsArray[$name] = $value;

--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -364,7 +364,6 @@ class ManageWikiFormFactoryBuilder {
 
 			if ( $add ) {
 				$value = $setList[$name] ?? null;
-
 				if ( isset( $set['associativeKey'] ) ) {
 					$value = $setList[$name][ $set['associativeKey'] ] ?? $set['overridedefault'][ $set['associativeKey'] ];
 				}

--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -987,29 +987,45 @@ class ManageWikiFormFactoryBuilder {
 
 			$value = $formData["set-$name"];
 
-			if ( $type == 'matrix' ) {
-				$settingsArray[$name] = ( $mwAllowed ) ? ManageWiki::handleMatrix( $value, 'phparray' ) : ManageWiki::handleMatrix( $current, 'php' );
-			} elseif ( $type == 'check' ) {
-				$settingsArray[$name] = ( $mwAllowed ) ? $value : $current;
-			} elseif ( $type == 'integers' ) {
-				$value = array_column( $value, 'value' );
-				$value = array_filter( $value );
-				$value = array_map( 'intval', $value );
-				$settingsArray[$name] = ( $mwAllowed ) ? $value : $current;
-			} elseif ( $type == 'texts' ) {
-				$value = array_column( $value, 'value' );
-				$value = array_filter( $value );
-				$settingsArray[$name] = ( $mwAllowed ) ? $value : $current;
-			} elseif ( $type == 'list-multi' || $type == 'usergroups' || $type == 'userrights' ) {
+			switch ( $type ) {
+				case 'integers':
+					$value = array_column( $value, 'value' );
+					$value = array_filter( $value );
+					$value = array_map( 'intval', $value );
+
+					break;
+				case 'list-multi-bool':
+					foreach ( $set['allopts'] as $opt ) {
+						$value[$opt] = in_array( $opt, $value );
+					}
+
+					break;
+				case 'matrix':
+					$current = ManageWiki::handleMatrix( $current, 'php' );
+					$value = ManageWiki::handleMatrix( $value, 'phparray' );
+
+					break;
+				case 'text':
+					if ( !$value ) {
+						$value = $current;
+					}
+
+					break;
+				case 'texts':
+					$value = array_column( $value, 'value' );
+					$value = array_filter( $value );
+
+					break;
+			}
+
+			if ( !$mwAllowed ) {
+				$value = $current;
+			}
+
+			if ( isset( $set['associativeKey'] ) ) {
+				$settingsArray[$name][ $set['associativeKey'] ] = $value;
+			} else {
 				$settingsArray[$name] = $value;
-			} elseif ( $type == 'list-multi-bool' ) {
-				foreach ( $set['allopts'] as $opt ) {
-					$settingsArray[$name][$opt] = in_array( $opt, $value );
-				}
-			} elseif ( $type != 'text' || $value ) {
-				$settingsArray[$name] = ( $mwAllowed ) ? $value : $current;
-			} elseif ( !$mwAllowed ) {
-					$settingsArray[$name] = $current;
 			}
 		}
 

--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -401,10 +401,9 @@ class ManageWikiFormFactoryBuilder {
 					];
 				}
 
+				$varName = " (\${$name})";
 				if ( isset( $set['associativeKey'] ) ) {
 					$varName = " (\${$name}['{$set['associativeKey']}'])";
-				} else {
-					$varName = " (\${$name})";
 				}
 
 				$formDescriptor["set-$name"] = [
@@ -993,10 +992,9 @@ class ManageWikiFormFactoryBuilder {
 				continue;
 			}
 
+			$current = $settingsList[$name] ?? $set['overridedefault'];
 			if ( isset( $set['associativeKey'] ) ) {
 				$current = $settingsList[$name][ $set['associativeKey'] ] ?? $set['overridedefault'][ $set['associativeKey'] ];
-			} else {
-				$current = $settingsList[$name] ?? $set['overridedefault'];
 			}
 
 			$mwAllowed = $set['requires'] ? ManageWikiRequirements::process( $set['requires'], $extList, false, $wiki ) : true;

--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -363,11 +363,13 @@ class ManageWikiFormFactoryBuilder {
 			$msgHelp = wfMessage( "managewiki-setting-{$name}-help" );
 
 			if ( $add ) {
+				$value = $setList[$name] ?? null;
+
 				if ( isset( $set['associativeKey'] ) ) {
-					$set['overridedefault'] = $set['overridedefault'][ $set['associativeKey'] ];
+					$value = $setList[$name][ $set['associativeKey'] ] ?? $set['overridedefault'][ $set['associativeKey'] ];
 				}
 
-				$configs = ManageWikiTypes::process( $config, $disabled, $groupList, 'settings', $set, $setList[$name] ?? null );
+				$configs = ManageWikiTypes::process( $config, $disabled, $groupList, 'settings', $set, $value );
 
 				$help = ( $msgHelp->exists() ) ? $msgHelp->text() : $set['help'];
 				if ( $set['requires'] ) {

--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -1034,6 +1034,10 @@ class ManageWikiFormFactoryBuilder {
 			}
 
 			if ( isset( $set['associativeKey'] ) ) {
+				if ( isset( $GLOBALS[$name] ) ) {
+					$settingsArray[$name] = $GLOBALS[$name];
+				}
+
 				$settingsArray[$name][ $set['associativeKey'] ] = $value;
 			} else {
 				$settingsArray[$name] = $value;

--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -1012,9 +1012,12 @@ class ManageWikiFormFactoryBuilder {
 
 					break;
 				case 'list-multi-bool':
+					$setValue = [];
 					foreach ( $set['allopts'] as $opt ) {
-						$value[$opt] = in_array( $opt, $value );
+						$setValue[$opt] = in_array( $opt, $value );
 					}
+
+					$value = $setValue;
 
 					break;
 				case 'matrix':


### PR DESCRIPTION
Should support configuration like the following:

```php
'wgExample' => [
	'associativeKey' => 'associativeKeyExample',
	'name' => 'Example Usage of AssociativeKey',
	'from' => 'mediawiki',
	'global' => true,
	'type' => 'text',
	'overridedefault' => [
		'associativeKeyExample' => 'example',
		'other-unmodified-associative-key-example' => [
			'example' => 'example',
		],
	],
	'section' => 'example',
	'help' => 'Example associative array configuration key.',
	'requires' => [],
],
```

Which should support configuring `$wgExample['associativeKeyExample']`.
This is just doing this the simplest way to achieve this probably. It would be nicer to achieve this using the below format, but if not done yet, that can probably be done later on without requiring additional steps to deploy, such as SQL queries, etc, should not be necessary:

```php
'wgExample' => [
	'associativeKeyExample' => [
		'name' => 'Example Usage of AssociativeKey',
		'from' => 'mediawiki',
		'global' => true,
		'type' => 'text',
		'overridedefault' => 'example',
		'section' => 'example',
		'help' => 'Example associative array configuration key.',
		'requires' => [],
	],
],
```

But that's a bit more complex for the code as they you have to manually check if its an associative array config value, and do associative `foreach` loops if so. So this may be the best way to achieve this instead.