### PR TITLE
Remove unused namespace(s) types

### DIFF
--- a/includes/Helpers/ManageWikiTypes.php
+++ b/includes/Helpers/ManageWikiTypes.php
@@ -139,18 +139,6 @@ class ManageWikiTypes {
 					'default' => ( isset( $value ) && $value !== null ) ? ManageWiki::handleMatrix( $value, 'php' ) : $options['overridedefault']
 				];
 				break;
-			case 'namespace':
-				$configs = [
-					'type' => 'namespaceselect',
-					'default' => $value ?? $options['overridedefault']
-				];
-				break;
-			case 'namespaces':
-				$configs = [
-					'type' => 'namespacesmultiselect',
-					'default' => $value ?? $options['overridedefault']
-				];
-				break;
 			case 'preferences':
 				$preferences = [];
 				$excludedPrefs = [];


### PR DESCRIPTION
Namespace configs are set via ManageWikiNamespaces, these types are unused.