### PR TITLE
Fix users and wikipages type return

### DIFF
--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -1039,7 +1039,7 @@ class ManageWikiFormFactoryBuilder {
 					break;
 				case 'users':
 				case 'wikipages':
-					$value = explode( "\n", $value );
+					$value = $value ? explode( "\n", $value ) : [];
 
 					break;
 			}


### PR DESCRIPTION
To prevent it from returning `[""]` (an array with an empty string)