### PR TITLE
Prevent deletion of global wiki

### DIFF
--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -75,7 +75,7 @@ class ManageWikiFormFactoryBuilder {
 			'section' => 'main'
 		];
 
-		if ( $ceMW && ( $config->get( 'DBname' ) == $config->get( 'CreateWikiGlobalWiki' ) ) ) {
+		if ( $ceMW && ( $config->get( 'DBname' ) == $config->get( 'CreateWikiGlobalWiki' ) ) && ( $wiki->getDBname() !== $config->get( 'CreateWikiGlobalWiki' ) ) ) {
 			$mwActions = [
 				( $wiki->isDeleted() ) ? 'undelete' : 'delete',
 				( $wiki->isLocked() ) ? 'unlock' : 'lock'
@@ -86,7 +86,6 @@ class ManageWikiFormFactoryBuilder {
 					'type' => 'check',
 					'label-message' => "managewiki-label-{$mwAction}wiki",
 					'default' => false,
-					'disabled' => $wiki->getDBname() == $config->get( 'CreateWikiGlobalWiki' ),
 					'section' => 'main'
 				];
 			}

--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -86,6 +86,7 @@ class ManageWikiFormFactoryBuilder {
 					'type' => 'check',
 					'label-message' => "managewiki-label-{$mwAction}wiki",
 					'default' => false,
+					'disabled' => $wiki->getDBname() == $config->get( 'CreateWikiGlobalWiki' ),
 					'section' => 'main'
 				];
 			}


### PR DESCRIPTION
The other day, I nearly deleted Meta as I thought I was on the /core page for another wiki. With this PR, the buttons to delete/lock the 'global wiki' are disabled so that no blunder can occur on the most important wiki.