### PR TITLE
Warn/lock if in read-only

### DIFF
--- a/includes/FormFactory/ManageWikiFormFactory.php
+++ b/includes/FormFactory/ManageWikiFormFactory.php
@@ -6,6 +6,7 @@ use Config;
 use Html;
 use HTMLForm;
 use IContextSource;
+use MediaWiki\MediaWikiServices;
 use Miraheze\CreateWiki\RemoteWiki;
 use Miraheze\ManageWiki\Helpers\ManageWikiOOUIForm;
 use Miraheze\ManageWiki\ManageWiki;
@@ -50,7 +51,7 @@ class ManageWikiFormFactory {
 
 		$htmlForm = new $formClass( $formDescriptor, $context, $module );
 
-		if ( !$ceMW ) {
+		if ( !$ceMW || MediaWikiServices::getInstance()->getReadOnlyMode()->isReadOnly() ) {
 			$htmlForm->suppressDefaultSubmit();
 		}
 

--- a/includes/Specials/SpecialManageWiki.php
+++ b/includes/Specials/SpecialManageWiki.php
@@ -118,6 +118,10 @@ class SpecialManageWiki extends SpecialPage {
 			$out->addModuleStyles( [ 'oojs-ui-widgets.styles' ] );
 		}
 
+		if ( MediaWikiServices::getInstance()->getReadOnlyMode()->isReadOnly() ) {
+			$out->addHTML( Html::errorBox( $this->msg( 'readonlytext', MediaWikiServices::getInstance()->getReadOnlyMode()->getReason() )->plain() ) );
+		}
+
 		if ( !$special ) {
 			$out->addWikiMsg( "managewiki-header-{$module}", $wiki );
 		}

--- a/includes/Specials/SpecialManageWikiDefaultPermissions.php
+++ b/includes/Specials/SpecialManageWikiDefaultPermissions.php
@@ -5,6 +5,7 @@ namespace Miraheze\ManageWiki\Specials;
 use Config;
 use GlobalVarConfig;
 use HTMLForm;
+use Html;
 use MediaWiki\MediaWikiServices;
 use Miraheze\CreateWiki\RemoteWiki;
 use Miraheze\ManageWiki\FormFactory\ManageWikiFormFactory;
@@ -29,6 +30,10 @@ class SpecialManageWikiDefaultPermissions extends SpecialPage {
 
 		if ( !ManageWiki::checkSetup( 'permissions', true, $out ) || !( $this->config->get( 'CreateWikiGlobalWiki' ) == $this->config->get( 'DBname' ) ) ) {
 			return false;
+		}
+
+		if ( MediaWikiServices::getInstance()->getReadOnlyMode()->isReadOnly() ) {
+			$out->addHTML( Html::errorBox( $this->msg( 'readonlytext', MediaWikiServices::getInstance()->getReadOnlyMode()->getReason() )->plain() ) );
 		}
 
 		if ( $par != '' ) {


### PR DESCRIPTION
Unlike CreateWiki, ManageWiki does not warn the user if the database is locked. It allows users to edit values freely and once you save, it complains. This adds a warning at the top of the page and hides the 'submit' button when locked.