### PR TITLE
add header for Special:DeletedWikis

### DIFF
--- a/includes/Specials/SpecialDeletedWikis.php
+++ b/includes/Specials/SpecialDeletedWikis.php
@@ -12,6 +12,7 @@ class SpecialDeletedWikis extends SpecialPage {
 
 	public function execute( $par ) {
 		$this->setHeaders();
+		$this->getOutput()->addWikiMsg( 'deletedwikis-header' );
 
 		$pager = new ManageWikiDeletedWikiPager( $this );
 


### PR DESCRIPTION
For people not familiar with it, it gives the impression that the list is a list of all wikis that have been deleted so there should be a short message explaining its purpose