### PR TITLE
Revert "add header for Special:DeletedWikis"

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -28,7 +28,6 @@
 	"apiwarn-wikiconfig-wikidoesnotexist": "Wiki '$1' does not exist.",
 	"core-main": "Main Settings",
 	"deletedwikis": "Deleted Wikis",
-	"deletedwikis-header": "This page contains a list of all wikis that have been marked as deleted by a Steward. After 14 days, wikis are eligible for permanent deletion. Once a wiki is permanently deleted, it will no longer show up in this list",
 	"extensions-other": "Other",
 	"log-description-managewiki": "This log tracks all changes to a wikis settings through ManageWiki.",
 	"log-name-managewiki": "ManageWiki log",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -33,7 +33,6 @@
 	"apiwarn-wikiconfig-wikidoesnotexist": "{{doc-apierror}}",
 	"core-main": "Used as a section header in Special:ManageWiki which is a page that allows administrators to manage their wiki's settings",
 	"deletedwikis": "Used as a heading in Special:DeletedWikis which is a page that lists deleted wikis",
-	"deletedwikis-header": "Used as a section header in Special:DeletedWikis which lists wikis marked for deletion",
 	"extensions-other": "{{Identical|Other}}",
 	"log-description-managewiki": "Description for the 'ManageWiki' log",
 	"log-name-managewiki": "Log name for ManageWiki",

--- a/includes/Specials/SpecialDeletedWikis.php
+++ b/includes/Specials/SpecialDeletedWikis.php
@@ -12,7 +12,6 @@ class SpecialDeletedWikis extends SpecialPage {
 
 	public function execute( $par ) {
 		$this->setHeaders();
-		$this->getOutput()->addWikiMsg( 'deletedwikis-header' );
 
 		$pager = new ManageWikiDeletedWikiPager( $this );
 

--- a/includes/Specials/SpecialDeletedWikis.php
+++ b/includes/Specials/SpecialDeletedWikis.php
@@ -12,6 +12,7 @@ class SpecialDeletedWikis extends SpecialPage {
 
 	public function execute( $par ) {
 		$this->setHeaders();
+		$this->outputHeader();
 
 		$pager = new ManageWikiDeletedWikiPager( $this );
 


### PR DESCRIPTION
Reverts miraheze/ManageWiki#382
This is Miraheze specific... a message like this is not needed for an override set in MirahezeMagic.

We use `SpecialPage::outputHeader()` instead, so the message can be set as `deletedwikis-summary` in MirahezeMagic, or nothing if the message does not exist. Doesn't need to be an override, just adding the message.