### PR TITLE
Correction of logentry-managewiki-rights

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -45,7 +45,7 @@
 	"logentry-managewiki-namespaces": "$1 modified the namespace \"$5\" for wiki \"$4\"",
 	"logentry-managewiki-namespaces-delete": "$1 deleted the namespace \"$5\" for wiki \"$4\"",
 	"logentry-managewiki-rename": "$1 renamed group $3 from $4",
-	"logentry-managewiki-rights": "$1 changed group metadata for $3: add rights $4; removed rights $5; added addgroups $6; removed addgroups $7; added removegroups $8; removed removegroups $9; added addgroupstoself $10; removed addgroupstoself $11; added removegroupsfromself $12; removed removegroupsfromself $13; modified autopromotion ($14)",
+	"logentry-managewiki-rights": "$1 changed group metadata for $3: added rights $4; removed rights $5; added addgroups $6; removed addgroups $7; added removegroups $8; removed removegroups $9; added addgroupstoself $10; removed addgroupstoself $11; added removegroupsfromself $12; removed removegroupsfromself $13; modified autopromotion ($14)",
 	"logentry-managewiki-settings": "$1 changed the settings ($5) for \"$4\"",
 	"logentry-managewiki-undelete": "$1 undeleted the wiki \"$4\"",
 	"logentry-managewiki-unlock": "$1 unlocked the wiki \"$4\"",


### PR DESCRIPTION
If I understand correctly, it's supposed to be "added" everywhere. If I misunderstand, please discard it. Thanks.