### PR TITLE
Restore "are" in managewiki-header-extensions

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -65,7 +65,7 @@
 	"managewiki-extension-name": "[$1 $2]",
 	"managewiki-extension-settings": "Manage available configuration options for this extension",
 	"managewiki-header-core": "Select what you would like to manage below, and click the save button to save your changes.",
-	"managewiki-header-extensions": "The extensions here  the ones that are currently installed, but you can always <span class=\"plainlinks\">[https://meta.miraheze.org/wiki/Request_features request]</span> another one to be added. <br> Once you are done, press the \"save\" button to save your changes.",
+	"managewiki-header-extensions": "The extensions here are the ones that are currently installed, but you can always <span class=\"plainlinks\">[https://meta.miraheze.org/wiki/Request_features request]</span> another one to be added. <br> Once you are done, press the \"save\" button to save your changes.",
 	"managewiki-header-namespaces": "Select a namespace to edit below (talk namespaces are associated to their main namespace) or press the button to create a new main namespace.",
 	"managewiki-header-permissions": "Select a group below that already exists to modify or create a new user group in the box below.",
 	"managewiki-header-settings": "This page is used to manage the wiki settings of wiki <b>'$1'</b>. If a feature you would like is not available here yet, please use <span class=\"plainlinks\">[https://meta.miraheze.org/wiki/Request_features Phabricator]</span> to request it. <br> Once you are done, press the \"save\" button to save your changes.",


### PR DESCRIPTION
This word was recently removed, and it probably happened by mistake.