### PR TITLE
Fix bug with creating MWN jobs on wiki creation

### DIFF
--- a/includes/Helpers/ManageWikiNamespaces.php
+++ b/includes/Helpers/ManageWikiNamespaces.php
@@ -237,7 +237,7 @@ class ManageWikiNamespaces {
 			}
 
 			$job = new NamespaceMigrationJob( SpecialPage::getTitleFor( 'ManageWiki' ), $jobParams );
-			MediaWikiServices::getInstance()->getJobQueueGroupFactory()->makeJobQueueGroup()->push( $job );
+			MediaWikiServices::getInstance()->getJobQueueGroupFactory()->makeJobQueueGroup( $this->wiki )->push( $job );
 		}
 
 		if ( $this->wiki != 'default' ) {


### PR DESCRIPTION
It was using the wiki that was creating the wiki rather then the wiki that has been created.