### PR TITLE
Pass 'wiki' along to NamespaceMigrationJob

### DIFF
--- a/includes/Helpers/ManageWikiNamespaces.php
+++ b/includes/Helpers/ManageWikiNamespaces.php
@@ -236,9 +236,8 @@ class ManageWikiNamespaces {
 				}
 			}
 
-			$job = new NamespaceMigrationJob( SpecialPage::getTitleFor( 'ManageWiki' ), $jobParams );
-			$nsWiki = $this->wiki == 'default' ? false : $this->wiki;
-			MediaWikiServices::getInstance()->getJobQueueGroupFactory()->makeJobQueueGroup( $nsWiki )->push( $job );
+			$job = new NamespaceMigrationJob( SpecialPage::getTitleFor( 'ManageWiki' ), $jobParams + [ 'wiki' => $this->wiki ] );
+			MediaWikiServices::getInstance()->getJobQueueGroupFactory()->makeJobQueueGroup()->push( $job );
 		}
 
 		if ( $this->wiki != 'default' ) {

--- a/includes/Helpers/ManageWikiNamespaces.php
+++ b/includes/Helpers/ManageWikiNamespaces.php
@@ -236,14 +236,17 @@ class ManageWikiNamespaces {
 				}
 			}
 
-			$job = new NamespaceMigrationJob( SpecialPage::getTitleFor( 'ManageWiki' ), $jobParams + [ 'wiki' => $this->wiki ] );
-			MediaWikiServices::getInstance()->getJobQueueGroupFactory()->makeJobQueueGroup()->push( $job );
+			if ( $this->wiki != 'default' ) {
+				$job = new NamespaceMigrationJob( SpecialPage::getTitleFor( 'ManageWiki' ), $jobParams + [ 'wiki' => $this->wiki ] );
+				MediaWikiServices::getInstance()->getJobQueueGroupFactory()->makeJobQueueGroup()->push( $job );
+			}
 		}
 
 		if ( $this->wiki != 'default' ) {
 			$cWJ = new CreateWikiJson( $this->wiki );
 			$cWJ->resetWiki();
 		}
+
 		$this->committed = true;
 	}
 

--- a/includes/Jobs/NamespaceMigrationJob.php
+++ b/includes/Jobs/NamespaceMigrationJob.php
@@ -22,9 +22,9 @@ class NamespaceMigrationJob extends Job {
 	 * @return bool
 	 */
 	public function run() {
-		$dbw = MediaWikiServices::getInstance()
-			->getDBLoadBalancer()
-			->getMaintenanceConnectionRef( DB_PRIMARY );
+		$dbw = MediaWikiServices::getInstance()->getDBLoadBalancerFactory()
+			->getMainLB( $this->params['wiki'] )
+			->getMaintenanceConnectionRef( DB_PRIMARY, [], $this->params['wiki'] );
 
 		$maintainPrefix = $this->params['maintainPrefix'];
 


### PR DESCRIPTION
We cannot use the wiki we're creating for creating jobs because LocalDatabases isn't updated in time. Instead lets pass along 'wiki' to the job and open the db connection with that.