### PR TITLE
Use run.php on MW 1.40+ to run scripts

### DIFF
--- a/includes/Jobs/MWScriptJob.php
+++ b/includes/Jobs/MWScriptJob.php
@@ -32,9 +32,15 @@ class MWScriptJob extends Job {
 			}
 		}
 
+		$scriptOptions = [];
+		if ( version_compare( MW_VERSION, '1.40', '>=' ) ) {
+			$scriptOptions = [ 'wrapper' => MW_INSTALL_PATH . '/maintenance/run.php' ];
+		}
+
 		$result = Shell::makeScriptCommand(
 			$this->params['script'],
-			$scriptParams
+			$scriptParams,
+			$scriptOptions
 		)->limits( [ 'memory' => 0, 'filesize' => 0 ] )->execute()->getExitCode();
 
 		// An execute code higher then 0 indicates failure.


### PR DESCRIPTION
Using scripts directly is deprecated as of MW 1.40. You have to use them with run.php.