### PR TITLE
Add missing i18n for managewikidefaultpermissions-view

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -172,6 +172,7 @@
 	"managewikidefaultpermissions-resetsettings-title": "Reset this wiki's settings to the defaults",
 	"managewikidefaultpermissions-resetsettings": "Reset settings to the defaults",
 	"managewikidefaultpermissions-select-info": "Below is a list of groups that are automatically created on new wikis. Use the dropdown below to select a group you wish to manage or view the configuration for.",
+	"managewikidefaultpermissions-view": "View default permissions for new wikis",
 	"managewikiextensions": "Manage a wiki's extensions",
 	"managewikinamespaces": "Manage a wiki's namespaces",
 	"managewikipermissions": "Manage a wiki's permissions",

--- a/includes/Specials/SpecialManageWikiDefaultPermissions.php
+++ b/includes/Specials/SpecialManageWikiDefaultPermissions.php
@@ -36,7 +36,7 @@ class SpecialManageWikiDefaultPermissions extends SpecialPage {
 	}
 
 	public function getDescription() {
-		return $this->msg( $this->canModify() ? 'managewikidefaultpermissions' : 'managewikidefaultpermissions-norights' )->text();
+		return $this->msg( $this->canModify() ? 'managewikidefaultpermissions' : 'managewikidefaultpermissions-view' )->text();
 	}
 
 	public function execute( $par ) {


### PR DESCRIPTION
This message, named managewikidefaultpermissions-norights, was introduced in https://github.com/miraheze/ManageWiki/pull/438. i18n for it was not added though.

This PR adds that missing i18n, in the same style as the other *-view messages.