### PR TITLE
Create an alias for special pages in Vietnamese

### DIFF
--- a/ManageWikiAliases.php
+++ b/ManageWikiAliases.php
@@ -7,3 +7,9 @@ $specialPageAliases['en'] = [
 	'ManageWiki' => [ 'ManageWiki' ],
 	'ManageWikiDefaultPermissions' => [ 'ManageWikiDefaultPermissions' ],
 ];
+
+$specialPageAliases['vi'] = [
+	'DeletedWikis' => [ 'Wiki bị xóa' ],
+	'ManageWiki' => [ 'Quản lý wiki' ],
+	'ManageWikiDefaultPermissions' => [ 'Quản lý quyền mặc định của wiki' ],
+];


### PR DESCRIPTION
Asked in Discord just to be sure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added Vietnamese language support for the ManageWiki functionality, enhancing localization with new aliases for key actions.
	- Users can now interact with the system using Vietnamese phrases for deleted wikis, manage wiki, and default permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->