### PR TITLE
ManageWikiExtensions: Log error if ext is not set in config && allow removing

### DIFF
--- a/includes/Helpers/ManageWikiExtensions.php
+++ b/includes/Helpers/ManageWikiExtensions.php
@@ -3,6 +3,7 @@
 namespace Miraheze\ManageWiki\Helpers;
 
 use MediaWiki\Config\Config;
+use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
 use Wikimedia\Rdbms\DBConnRef;
 
@@ -100,7 +101,7 @@ class ManageWikiExtensions {
 	 * @param string|string[] $extensions Either an array or string of extensions to disable
 	 * @param bool $forceRemove Force removing extension incase it is removed from config
 	 */
-	public function remove( $extensions, $forceRemove ) {
+	public function remove( $extensions, $forceRemove = false ) {
 		// We allow remove either one extension (string) or many (array)
 		// We will handle all processing in final stages
 		foreach ( (array)$extensions as $ext ) {
@@ -108,8 +109,7 @@ class ManageWikiExtensions {
 				continue;
 			}
 
-			$this->removedExts[$ext] = isset( $this->liveExts[$ext] ) ?
-				$this->liveExts[$ext] : [];
+			$this->removedExts[$ext] = $this->liveExts[$ext] ?? [];
 			unset( $this->liveExts[$ext] );
 
 			$this->changes[$ext] = [

--- a/includes/Helpers/ManageWikiExtensions.php
+++ b/includes/Helpers/ManageWikiExtensions.php
@@ -55,9 +55,20 @@ class ManageWikiExtensions {
 			]
 		)->s_extensions ?? '[]';
 
+		$logger = LoggerFactory::getInstance( 'ManageWiki' );
+
 		// To simplify clean up and to reduce the need to constantly refer back to many different variables, we now
 		// populate extension lists with config associated with them.
 		foreach ( json_decode( $exts, true ) as $ext ) {
+			if ( !isset( $this->extConfig[$ext] ) ) {
+				$logger->error( 'Extension {ext} not set in wgManageWikiExtensions', [
+					'ext' => $ext,
+				] );
+				// We need to set an empty array and to set
+				// the ext in liveExts. This is so it can be removed.
+				$this->liveExts[$ext] = [];
+				continue;
+			}
 			$this->liveExts[$ext] = $this->extConfig[$ext];
 		}
 	}

--- a/includes/Helpers/ManageWikiExtensions.php
+++ b/includes/Helpers/ManageWikiExtensions.php
@@ -108,7 +108,8 @@ class ManageWikiExtensions {
 				continue;
 			}
 
-			$this->removedExts[$ext] = $this->liveExts[$ext];
+			$this->removedExts[$ext] = isset( $this->liveExts[$ext] ) ?
+				$this->liveExts[$ext] : [];
 			unset( $this->liveExts[$ext] );
 
 			$this->changes[$ext] = [

--- a/includes/Helpers/ManageWikiExtensions.php
+++ b/includes/Helpers/ManageWikiExtensions.php
@@ -61,7 +61,7 @@ class ManageWikiExtensions {
 		// populate extension lists with config associated with them.
 		foreach ( json_decode( $exts, true ) as $ext ) {
 			if ( !isset( $this->extConfig[$ext] ) ) {
-				$logger->error( 'Extension {ext} not set in wgManageWikiExtensions', [
+				$logger->error( 'Extension/Skin {ext} not set in wgManageWikiExtensions', [
 					'ext' => $ext,
 				] );
 				continue;

--- a/includes/Helpers/ManageWikiExtensions.php
+++ b/includes/Helpers/ManageWikiExtensions.php
@@ -98,7 +98,7 @@ class ManageWikiExtensions {
 	/**
 	 * Removes an extension from the 'enabled' list
 	 * @param string|string[] $extensions Either an array or string of extensions to disable
-  	 * @param bool $forceRemove Force removing extension incase it is removed from config
+	 * @param bool $forceRemove Force removing extension incase it is removed from config
 	 */
 	public function remove( $extensions, $forceRemove ) {
 		// We allow remove either one extension (string) or many (array)

--- a/includes/Helpers/ManageWikiExtensions.php
+++ b/includes/Helpers/ManageWikiExtensions.php
@@ -64,9 +64,6 @@ class ManageWikiExtensions {
 				$logger->error( 'Extension {ext} not set in wgManageWikiExtensions', [
 					'ext' => $ext,
 				] );
-				// We need to set an empty array and to set
-				// the ext in liveExts. This is so it can be removed.
-				$this->liveExts[$ext] = [];
 				continue;
 			}
 			$this->liveExts[$ext] = $this->extConfig[$ext];
@@ -101,12 +98,13 @@ class ManageWikiExtensions {
 	/**
 	 * Removes an extension from the 'enabled' list
 	 * @param string|string[] $extensions Either an array or string of extensions to disable
+  	 * @param bool $forceRemove Force removing extension incase it is removed from config
 	 */
-	public function remove( $extensions ) {
+	public function remove( $extensions, $forceRemove ) {
 		// We allow remove either one extension (string) or many (array)
 		// We will handle all processing in final stages
 		foreach ( (array)$extensions as $ext ) {
-			if ( !isset( $this->liveExts[$ext] ) ) {
+			if ( !isset( $this->liveExts[$ext] ) && !$forceRemove ) {
 				continue;
 			}
 

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -80,7 +80,7 @@ class Hooks {
 					$cacheArray['extensions'][] = $manageWikiExtensions[$ext]['var'] ??
 						$manageWikiExtensions[$ext]['name'];
 				} else {
-					$logger->error( 'Extension {ext} not set in wgManageWikiExtensions', [
+					$logger->error( 'Extension/Skin {ext} not set in wgManageWikiExtensions', [
 						'ext' => $ext,
 					] );
 				}

--- a/maintenance/toggleExtension.php
+++ b/maintenance/toggleExtension.php
@@ -24,11 +24,13 @@ class ToggleExtension extends Maintenance {
 		$this->addOption( 'all-wikis', 'Run on all wikis present in $wgLocalDatabases.' );
 		$this->addOption( 'confirm', 'Confirm execution. Required if using --all-wikis' );
 		$this->addOption( 'no-list', 'Don\'t list on which wikis this script has ran. This may speed up execution.' );
+		$this->addOption( 'force-remove', 'Force removal of extension when not in config.' );
 
 		$this->requireExtension( 'ManageWiki' );
 	}
 
 	public function execute() {
+		$forceRemove = $this->getOption( 'force-remove', false );
 		$noList = $this->getOption( 'no-list', false );
 		$allWikis = $this->getOption( 'all-wikis', false );
 		$wikis = $allWikis ?
@@ -46,7 +48,7 @@ class ToggleExtension extends Maintenance {
 			$mwExt = new ManageWikiExtensions( $wiki );
 			$extensionList = $mwExt->list();
 			if ( $disable && in_array( $ext, $extensionList ) ) {
-				$mwExt->remove( $ext );
+				$mwExt->remove( $ext, $forceRemove );
 				$mwExt->commit();
 				if ( !$noList ) {
 					$this->output( "Removed $ext from $wiki" );


### PR DESCRIPTION
* Logs error if ext does not exist in config.
* Allows removing ext when it does not exist in config.

Bug: T12868