### PR TITLE
T12896: Fix deleting groups with no permissions

### DIFF
--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -795,7 +795,7 @@ class ManageWikiFormFactoryBuilder {
 
 		if (
 			$ceMW &&
-			count( $permList['permissions'] ?? [] ) > 0 &&
+			$mwPermissions->exists( $group ) &&
 			!in_array( $group, $config->get( 'ManageWikiPermissionsPermanentGroups' ) )
 		) {
 			$formDescriptor['delete-checkbox'] = [

--- a/includes/Helpers/ManageWikiPermissions.php
+++ b/includes/Helpers/ManageWikiPermissions.php
@@ -66,6 +66,15 @@ class ManageWikiPermissions {
 	}
 
 	/**
+	 * Checks whether or not the specified group exists
+	 * @param string $group Group to check
+	 * @return bool Whether or not the group exists
+	 */
+	public function exists( string $group ): bool {
+		return array_key_exists( $group, $this->livePermissions );
+	}
+
+	/**
 	 * Lists either all groups or a specific one
 	 * @param string|null $group Group wanted (null for all)
 	 * @return array Group configuration


### PR DESCRIPTION
While they shouldn't exist (the code automatically deletes groups if all rights are removed from them), they apparently sometimes happen anyway (otherwise, this bug wouldn't have been noticed).

Closes T12896