### PR TITLE
ManageWikiExtensions: Don't look for s_settings or s_extensions in upset

### DIFF
--- a/includes/Helpers/ManageWikiExtensions.php
+++ b/includes/Helpers/ManageWikiExtensions.php
@@ -236,9 +236,7 @@ class ManageWikiExtensions {
 		$this->dbw->upsert(
 			'mw_settings',
 			[
-				's_dbname' => $this->wiki,
-				's_settings' => json_encode( [] ),
-				's_extensions' => json_encode( $this->list() )
+				's_dbname' => $this->wiki
 			],
 			[ [ 's_dbname' ] ],
 			[


### PR DESCRIPTION
We only require one entry.