### PR TITLE
ManageWikiExtensions: Don't look for s_settings in upsert

### DIFF
--- a/includes/Helpers/ManageWikiExtensions.php
+++ b/includes/Helpers/ManageWikiExtensions.php
@@ -237,7 +237,6 @@ class ManageWikiExtensions {
 			'mw_settings',
 			[
 				's_dbname' => $this->wiki,
-				's_settings' => json_encode( [] ),
 				's_extensions' => json_encode( $this->list() )
 			],
 			[ [ 's_dbname' ] ],


### PR DESCRIPTION
We were using json_encode with an empty array.