### PR TITLE
ManageWikiSettings: Don't look for s_extensions in upsert

### DIFF
--- a/includes/Helpers/ManageWikiSettings.php
+++ b/includes/Helpers/ManageWikiSettings.php
@@ -164,7 +164,6 @@ class ManageWikiSettings {
 			'mw_settings',
 			[
 				's_dbname' => $this->wiki,
-				's_extensions' => json_encode( [] ),
 				's_settings' => json_encode( $this->liveSettings )
 			],
 			[ [ 's_dbname' ] ],


### PR DESCRIPTION
We were using json_encode with an empty array.