### PR TITLE
ManageWikiTypes: Lowe case group for uaergroups types

### DIFF
--- a/includes/Helpers/ManageWikiTypes.php
+++ b/includes/Helpers/ManageWikiTypes.php
@@ -332,7 +332,8 @@ class ManageWikiTypes {
 				$language = RequestContext::getMain()->getLanguage();
 				$groups = [];
 				foreach ( (array)$groupList as $group ) {
-					$groups[htmlspecialchars( $language->getGroupName( $group ) )] = $group;
+					$lowerCaseGroupName = strtolower( $group );
+					$groups[htmlspecialchars( $language->getGroupName( $lowerCaseGroupName ) )] = $lowerCaseGroupName;
 				}
 
 				$configs = [


### PR DESCRIPTION
Matches change done in Special:ManageWiki.