### PR TITLE
Fix typo in autopromotion message

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -130,7 +130,7 @@
 	"managewiki-permissions-addall": "Can add to others",
 	"managewiki-permissions-addself": "Can add to self",
 	"managewiki-permissions-assigned": "The below user rights are currently assigned to this user group.",
-	"managewiki-permissions-autopromote": "Below you can manage autopromotion of users to this group. Note that if a user matches the critera you set below, they will inherit all permissions of this group and you can not remove them from this group under any circumstance unless you select promoting them once before they meet the criteria.",
+	"managewiki-permissions-autopromote": "Below you can manage autopromotion of users to this group. Note that if a user matches the criteria you set below, they will inherit all permissions of this group and you can not remove them from this group under any circumstance unless you select promoting them once before they meet the criteria.",
 	"managewiki-permissions-autopromote-age": "Must have been a user for the following number of days",
 	"managewiki-permissions-autopromote-blocked": "Must be blocked",
 	"managewiki-permissions-autopromote-bot": "Must be a bot account",


### PR DESCRIPTION
Changed "critera" to "criteria".