### PR TITLE
Cleanup/modernize maintenance scripts

### DIFF
--- a/maintenance/AddNamespaces.php
+++ b/maintenance/AddNamespaces.php
@@ -2,15 +2,8 @@
 
 namespace Miraheze\ManageWiki\Maintenance;
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
-use Maintenance;
 use MediaWiki\MainConfigNames;
+use MediaWiki\Maintenance\Maintenance;
 use Miraheze\ManageWiki\Helpers\ManageWikiNamespaces;
 
 class AddNamespaces extends Maintenance {
@@ -49,5 +42,6 @@ class AddNamespaces extends Maintenance {
 	}
 }
 
-$maintClass = AddNamespaces::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return AddNamespaces::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/ModifyGroupPermission.php
+++ b/maintenance/ModifyGroupPermission.php
@@ -2,15 +2,8 @@
 
 namespace Miraheze\ManageWiki\Maintenance;
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
-use Maintenance;
 use MediaWiki\MainConfigNames;
+use MediaWiki\Maintenance\Maintenance;
 use Miraheze\ManageWiki\Helpers\ManageWikiPermissions;
 
 class ModifyGroupPermission extends Maintenance {
@@ -79,5 +72,6 @@ class ModifyGroupPermission extends Maintenance {
 	}
 }
 
-$maintClass = ModifyGroupPermission::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return ModifyGroupPermission::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/PopulateGroupPermissions.php
+++ b/maintenance/PopulateGroupPermissions.php
@@ -2,15 +2,8 @@
 
 namespace Miraheze\ManageWiki\Maintenance;
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
-use Maintenance;
 use MediaWiki\MainConfigNames;
+use MediaWiki\Maintenance\Maintenance;
 use Miraheze\ManageWiki\ManageWiki;
 
 class PopulateGroupPermissions extends Maintenance {
@@ -106,5 +99,6 @@ class PopulateGroupPermissions extends Maintenance {
 	}
 }
 
-$maintClass = PopulateGroupPermissions::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return PopulateGroupPermissions::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/PopulateGroupPermissionsWithDefaults.php
+++ b/maintenance/PopulateGroupPermissionsWithDefaults.php
@@ -2,15 +2,8 @@
 
 namespace Miraheze\ManageWiki\Maintenance;
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
-use Maintenance;
 use MediaWiki\MainConfigNames;
+use MediaWiki\Maintenance\Maintenance;
 use Miraheze\ManageWiki\Helpers\ManageWikiPermissions;
 
 class PopulateGroupPermissionsWithDefaults extends Maintenance {
@@ -76,5 +69,6 @@ class PopulateGroupPermissionsWithDefaults extends Maintenance {
 	}
 }
 
-$maintClass = PopulateGroupPermissionsWithDefaults::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return PopulateGroupPermissionsWithDefaults::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/PopulateNamespaces.php
+++ b/maintenance/PopulateNamespaces.php
@@ -2,15 +2,8 @@
 
 namespace Miraheze\ManageWiki\Maintenance;
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
-use Maintenance;
 use MediaWiki\MainConfigNames;
+use MediaWiki\Maintenance\Maintenance;
 use Miraheze\ManageWiki\ManageWiki;
 use Wikimedia\AtEase\AtEase;
 
@@ -90,5 +83,6 @@ class PopulateNamespaces extends Maintenance {
 	}
 }
 
-$maintClass = PopulateNamespaces::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return PopulateNamespaces::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/PopulateNamespacesWithDefaults.php
+++ b/maintenance/PopulateNamespacesWithDefaults.php
@@ -2,15 +2,8 @@
 
 namespace Miraheze\ManageWiki\Maintenance;
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
-use Maintenance;
 use MediaWiki\MainConfigNames;
+use MediaWiki\Maintenance\Maintenance;
 use Miraheze\ManageWiki\Helpers\ManageWikiNamespaces;
 
 class PopulateNamespacesWithDefaults extends Maintenance {
@@ -64,5 +57,6 @@ class PopulateNamespacesWithDefaults extends Maintenance {
 	}
 }
 
-$maintClass = PopulateNamespacesWithDefaults::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return PopulateNamespacesWithDefaults::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/PopulateWikiSettings.php
+++ b/maintenance/PopulateWikiSettings.php
@@ -2,15 +2,8 @@
 
 namespace Miraheze\ManageWiki\Maintenance;
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
-use Maintenance;
 use MediaWiki\MainConfigNames;
+use MediaWiki\Maintenance\Maintenance;
 use Miraheze\ManageWiki\Helpers\ManageWikiSettings;
 
 class PopulateWikiSettings extends Maintenance {
@@ -56,5 +49,6 @@ class PopulateWikiSettings extends Maintenance {
 	}
 }
 
-$maintClass = PopulateWikiSettings::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return PopulateWikiSettings::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/RemoveSettings.php
+++ b/maintenance/RemoveSettings.php
@@ -2,15 +2,8 @@
 
 namespace Miraheze\ManageWiki\Maintenance;
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
-use Maintenance;
 use MediaWiki\MainConfigNames;
+use MediaWiki\Maintenance\Maintenance;
 use Miraheze\ManageWiki\Helpers\ManageWikiSettings;
 
 class RemoveSettings extends Maintenance {
@@ -31,5 +24,6 @@ class RemoveSettings extends Maintenance {
 	}
 }
 
-$maintClass = RemoveSettings::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return RemoveSettings::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/ToggleExtension.php
+++ b/maintenance/ToggleExtension.php
@@ -2,15 +2,8 @@
 
 namespace Miraheze\ManageWiki\Maintenance;
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
-use Maintenance;
 use MediaWiki\MainConfigNames;
+use MediaWiki\Maintenance\Maintenance;
 use MediaWiki\WikiMap\WikiMap;
 use Miraheze\ManageWiki\Helpers\ManageWikiExtensions;
 
@@ -72,5 +65,6 @@ class ToggleExtension extends Maintenance {
 	}
 }
 
-$maintClass = ToggleExtension::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return ToggleExtension::class;
+// @codeCoverageIgnoreEnd


### PR DESCRIPTION
### Maintenance Scripts Now Require `run.php`

Maintenance scripts **can no longer be run directly** by passing them to the PHP interpreter. Instead, they now **require** `run.php`.

#### New Usage:
Scripts can now be executed using either of the following methods:

- **Without PHP explicitly:**
  ```sh
  maintenance/run ManageWiki:ToggleExtension
  ```
- **Using PHP:**
  ```sh
  php maintenance/run.php ManageWiki:ToggleExtension
  ```

This change significantly simplifies calling maintenance scripts, reducing the steps needed.

#### Impact on Miraheze:

For Miraheze, this means scripts can now be executed using mwscript more conveniently. For example:

```sh
mwscript ManageWiki:ToggleExtension
```