### PR TITLE
Add redirect when deleting groups and namespaces

### DIFF
--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -891,7 +891,7 @@ class ManageWikiFormFactoryBuilder {
 			$mwLogID = $mwLogEntry->insert();
 			$mwLogEntry->publish( $mwLogID );
 
-			if ( $module === 'permissions' || $module === 'namespace' ) {
+			if ( $module === 'permissions' || $module === 'namespaces' ) {
 				if ( $mwReturn->isDeleting( $special ) ) {
 					$context->getOutput()->redirect(
 						SpecialPage::getTitleFor( 'ManageWiki', $module )->getFullURL()

--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -892,6 +892,7 @@ class ManageWikiFormFactoryBuilder {
 			$mwLogEntry->publish( $mwLogID );
 
 			if ( $module === 'permissions' || $module === 'namespaces' ) {
+				$context->getRequest()->getSession()->set( 'manageWikiSaveSuccess', 1 );
 				if ( $mwReturn->isDeleting( $special ) ) {
 					$context->getOutput()->redirect(
 						SpecialPage::getTitleFor( 'ManageWiki', $module )->getFullURL()

--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -890,6 +890,14 @@ class ManageWikiFormFactoryBuilder {
 			$mwLogEntry->setParameters( $mwReturn->getLogParams() );
 			$mwLogID = $mwLogEntry->insert();
 			$mwLogEntry->publish( $mwLogID );
+
+			if ( $module === 'permissions' || $module === 'namespace' ) {
+				if ( $mwReturn->isDeleting( $special ) ) {
+					$context->getOutput()->redirect(
+						SpecialPage::getTitleFor( 'ManageWiki', $module )->getFullURL()
+					);
+				}
+			}
 		} else {
 			return [ [ 'managewiki-changes-none' => null ] ];
 		}

--- a/includes/FormFactory/ManageWikiFormFactoryBuilder.php
+++ b/includes/FormFactory/ManageWikiFormFactoryBuilder.php
@@ -892,8 +892,8 @@ class ManageWikiFormFactoryBuilder {
 			$mwLogEntry->publish( $mwLogID );
 
 			if ( $module === 'permissions' || $module === 'namespaces' ) {
-				$context->getRequest()->getSession()->set( 'manageWikiSaveSuccess', 1 );
 				if ( $mwReturn->isDeleting( $special ) ) {
+					$context->getRequest()->getSession()->set( 'manageWikiSaveSuccess', 1 );
 					$context->getOutput()->redirect(
 						SpecialPage::getTitleFor( 'ManageWiki', $module )->getFullURL()
 					);

--- a/includes/Helpers/ManageWikiNamespaces.php
+++ b/includes/Helpers/ManageWikiNamespaces.php
@@ -178,6 +178,10 @@ class ManageWikiNamespaces implements IConfigModule {
 		$this->runNamespaceMigrationJob = false;
 	}
 
+	public function isDeleting( int|string $namespace ): bool {
+		return in_array( (int)$namespace, $this->deleteNamespaces );
+	}
+
 	public function getErrors(): array {
 		return $this->errors;
 	}
@@ -204,7 +208,7 @@ class ManageWikiNamespaces implements IConfigModule {
 
 	public function commit(): void {
 		foreach ( array_keys( $this->changes ) as $id ) {
-			if ( in_array( $id, $this->deleteNamespaces ) ) {
+			if ( $this->isDeleting( $id ) ) {
 				$this->log = 'namespaces-delete';
 
 				if ( !$this->isTalk( $id ) ) {

--- a/includes/Helpers/ManageWikiPermissions.php
+++ b/includes/Helpers/ManageWikiPermissions.php
@@ -149,6 +149,10 @@ class ManageWikiPermissions implements IConfigModule {
 		$this->deleteGroups[] = $group;
 	}
 
+	public function isDeleting( string $group ): bool {
+		return in_array( $group, $this->deleteGroups );
+	}
+
 	public function getErrors(): array {
 		return $this->errors;
 	}
@@ -177,7 +181,7 @@ class ManageWikiPermissions implements IConfigModule {
 		$logNULL = wfMessage( 'rightsnone' )->inContentLanguage()->text();
 
 		foreach ( array_keys( $this->changes ) as $group ) {
-			if ( in_array( $group, $this->deleteGroups ) ) {
+			if ( $this->isDeleting( $group ) ) {
 				$this->log = 'delete-group';
 
 				$this->dbw->delete(

--- a/includes/Specials/SpecialManageWiki.php
+++ b/includes/Specials/SpecialManageWiki.php
@@ -41,6 +41,27 @@ class SpecialManageWiki extends SpecialPage {
 			);
 		}
 
+		$session = $this->getRequest()->getSession();
+		if ( $session->get( 'manageWikiSaveSuccess' ) ) {
+			// Remove session data for the success message
+			$session->remove( 'manageWikiSaveSuccess' );
+			$out->addModuleStyles( [
+				'mediawiki.codex.messagebox.styles',
+				'mediawiki.notification.convertmessagebox.styles',
+			] );
+
+			$out->addHTML(
+				Html::successBox(
+					Html::element(
+						'p',
+						[],
+						$this->msg( 'managewiki-success' )->text()
+					),
+					'mw-notify-success'
+				)
+			);
+		}
+
 		$module = 'core';
 		if ( array_key_exists( $par[0], $this->getConfig()->get( ConfigNames::ManageWiki ) ) ) {
 			$module = $par[0];

--- a/includes/Specials/SpecialManageWiki.php
+++ b/includes/Specials/SpecialManageWiki.php
@@ -45,12 +45,12 @@ class SpecialManageWiki extends SpecialPage {
 		if ( $session->get( 'manageWikiSaveSuccess' ) ) {
 			// Remove session data for the success message
 			$session->remove( 'manageWikiSaveSuccess' );
-			$out->addModuleStyles( [
+			$this->getOutput()->addModuleStyles( [
 				'mediawiki.codex.messagebox.styles',
 				'mediawiki.notification.convertmessagebox.styles',
 			] );
 
-			$out->addHTML(
+			$this->getOutput()->addHTML(
 				Html::successBox(
 					Html::element(
 						'p',

--- a/includes/Specials/SpecialManageWiki.php
+++ b/includes/Specials/SpecialManageWiki.php
@@ -41,27 +41,6 @@ class SpecialManageWiki extends SpecialPage {
 			);
 		}
 
-		$session = $this->getRequest()->getSession();
-		if ( $session->get( 'manageWikiSaveSuccess' ) ) {
-			// Remove session data for the success message
-			$session->remove( 'manageWikiSaveSuccess' );
-			$this->getOutput()->addModuleStyles( [
-				'mediawiki.codex.messagebox.styles',
-				'mediawiki.notification.convertmessagebox.styles',
-			] );
-
-			$this->getOutput()->addHTML(
-				Html::successBox(
-					Html::element(
-						'p',
-						[],
-						$this->msg( 'managewiki-success' )->text()
-					),
-					'mw-notify-success'
-				)
-			);
-		}
-
 		$module = 'core';
 		if ( array_key_exists( $par[0], $this->getConfig()->get( ConfigNames::ManageWiki ) ) ) {
 			$module = $par[0];
@@ -181,17 +160,31 @@ class SpecialManageWiki extends SpecialPage {
 		string $special,
 		string $filtered
 	): void {
-		if ( $special !== '' || in_array( $module, [ 'core', 'extensions', 'settings' ] ) ) {
-			$this->getOutput()->addModules( [
-				'ext.managewiki.oouiform',
-				'mediawiki.special.userrights',
-			] );
+		$this->getOutput()->addModules( [
+			'ext.managewiki.oouiform',
+			'mediawiki.special.userrights',
+		] );
 
-			$this->getOutput()->addModuleStyles( [
-				'ext.managewiki.oouiform.styles',
-				'mediawiki.widgets.TagMultiselectWidget.styles',
-				'oojs-ui-widgets.styles',
-			] );
+		$this->getOutput()->addModuleStyles( [
+			'ext.managewiki.oouiform.styles',
+			'mediawiki.widgets.TagMultiselectWidget.styles',
+			'oojs-ui-widgets.styles',
+		] );
+		
+		$session = $this->getRequest()->getSession();
+		if ( $session->get( 'manageWikiSaveSuccess' ) ) {
+			// Remove session data for the success message
+			$session->remove( 'manageWikiSaveSuccess' );
+			$this->getOutput()->addHTML(
+				Html::successBox(
+					Html::element(
+						'p',
+						[],
+						$this->msg( 'managewiki-success' )->text()
+					),
+					'mw-notify-success'
+				)
+			);
 		}
 
 		$remoteWiki = $this->remoteWikiFactory->newInstance( $dbname );


### PR DESCRIPTION
To solve numerous bugs with change tracking if you reload multiple times when deleting groups and namespaces.