### PR TITLE
Run void hooks as non-abortable

### DIFF
--- a/includes/Hooks/ManageWikiHookRunner.php
+++ b/includes/Hooks/ManageWikiHookRunner.php
@@ -27,7 +27,8 @@ class ManageWikiHookRunner implements
 	): void {
 		$this->container->run(
 			'ManageWikiCoreAddFormFields',
-			[ $context, $remoteWiki, $dbname, $ceMW, &$formDescriptor ]
+			[ $context, $remoteWiki, $dbname, $ceMW, &$formDescriptor ],
+			[ 'abortable' => false ]
 		);
 	}
 
@@ -41,7 +42,8 @@ class ManageWikiHookRunner implements
 	): void {
 		$this->container->run(
 			'ManageWikiCoreFormSubmission',
-			[ $context, $dbw, $remoteWiki, $dbname, $formData ]
+			[ $context, $dbw, $remoteWiki, $dbname, $formData ],
+			[ 'abortable' => false ]
 		);
 	}
 }


### PR DESCRIPTION
An upcoming MediaWiki core change ([I858d5dc02c](https://gerrit.wikimedia.org/r/c/mediawiki/core/+/1136337)) will enforce this in `HookRunnerTestBase`; given that the `HookContainer::run()` return value isn’t checked, these hooks were likely not meant to be abortable, though I confess I haven’t looked into it in detail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal hook execution behavior to ensure certain operations are not interruptible. No visible changes to end-user features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->