### PR TITLE
Add hook to add sidebar links to managewiki-sidebar-header

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -195,6 +195,7 @@
 			"class": "Miraheze\\ManageWiki\\Hooks\\Handlers\\Main",
 			"services": [
 				"ManageWikiConfig",
+				"ManageWikiHookRunner",
 				"UserOptionsLookup"
 			]
 		}

--- a/includes/Hooks/Handlers/Main.php
+++ b/includes/Hooks/Handlers/Main.php
@@ -66,6 +66,7 @@ class Main implements
 		if ( isset( $sidebar['managewiki-sidebar-header'] ) ) {
 			$sidebarLinks = $sidebar['managewiki-sidebar-header'];
 			$this->hookRunner->onManageWikiAfterSidebarLinks( $skin, $sidebarLinks );
+			$sidebar['managewiki-sidebar-header'] = $sidebarLinks;
 		}
 	}
 }

--- a/includes/Hooks/Handlers/Main.php
+++ b/includes/Hooks/Handlers/Main.php
@@ -10,6 +10,7 @@ use MediaWiki\Preferences\Hook\GetPreferencesHook;
 use MediaWiki\SpecialPage\SpecialPage;
 use MediaWiki\User\Options\UserOptionsLookup;
 use Miraheze\ManageWiki\ConfigNames;
+use Miraheze\ManageWiki\Hooks\ManageWikiHookRunner;
 
 class Main implements
 	ContentHandlerForModelIDHook,
@@ -19,6 +20,7 @@ class Main implements
 
 	public function __construct(
 		private readonly Config $config,
+		private readonly ManageWikiHookRunner $hookRunner,
 		private readonly UserOptionsLookup $userOptionsLookup
 	) {
 	}
@@ -59,6 +61,10 @@ class Main implements
 				'id' => "managewiki{$module}link",
 				'href' => htmlspecialchars( SpecialPage::getTitleFor( 'ManageWiki', $module )->getFullURL() ),
 			];
+		}
+
+		if ( isset( $sidebar['managewiki-sidebar-header'] ) ) {
+			$this->hookRunner->onManageWikiAfterSidebarLinks( $skin, $sidebar );
 		}
 	}
 }

--- a/includes/Hooks/Handlers/Main.php
+++ b/includes/Hooks/Handlers/Main.php
@@ -64,7 +64,8 @@ class Main implements
 		}
 
 		if ( isset( $sidebar['managewiki-sidebar-header'] ) ) {
-			$this->hookRunner->onManageWikiAfterSidebarLinks( $skin, $sidebar );
+			$sidebarLinks = $sidebar['managewiki-sidebar-header'];
+			$this->hookRunner->onManageWikiAfterSidebarLinks( $skin, $sidebarLinks );
 		}
 	}
 }

--- a/includes/Hooks/ManageWikiAfterSidebarLinksHook.php
+++ b/includes/Hooks/ManageWikiAfterSidebarLinksHook.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Miraheze\ManageWiki\Hooks;
+
+use Skin;
+
+interface ManageWikiAfterSidebarLinksHook {
+
+	/**
+	 * @param Skin $skin
+	 * @param array &$sidebar
+	 * @return void
+	 */
+	public function onManageWikiAfterSidebarLinks( Skin $skin, array &$sidebar ): void;
+}

--- a/includes/Hooks/ManageWikiAfterSidebarLinksHook.php
+++ b/includes/Hooks/ManageWikiAfterSidebarLinksHook.php
@@ -8,8 +8,8 @@ interface ManageWikiAfterSidebarLinksHook {
 
 	/**
 	 * @param Skin $skin
-	 * @param array &$sidebar
+	 * @param array &$sidebarLinks
 	 * @return void
 	 */
-	public function onManageWikiAfterSidebarLinks( Skin $skin, array &$sidebar ): void;
+	public function onManageWikiAfterSidebarLinks( Skin $skin, array &$sidebarLinks ): void;
 }

--- a/includes/Hooks/ManageWikiHookRunner.php
+++ b/includes/Hooks/ManageWikiHookRunner.php
@@ -19,10 +19,10 @@ class ManageWikiHookRunner implements
 	}
 
 	/** @inheritDoc */
-	public function onManageWikiAfterSidebarLinks( Skin $skin, array &$sidebar ): void {
+	public function onManageWikiAfterSidebarLinks( Skin $skin, array &$sidebarLinks ): void {
 		$this->container->run(
 			'ManageWikiAfterSidebarLinks',
-			[ $skin, &$sidebar ],
+			[ $skin, &$sidebarLinks ],
 			[ 'abortable' => false ]
 		);
 	}

--- a/includes/Hooks/ManageWikiHookRunner.php
+++ b/includes/Hooks/ManageWikiHookRunner.php
@@ -5,8 +5,10 @@ namespace Miraheze\ManageWiki\Hooks;
 use MediaWiki\Context\IContextSource;
 use MediaWiki\HookContainer\HookContainer;
 use Miraheze\ManageWiki\Helpers\Factories\ModuleFactory;
+use Skin;
 
 class ManageWikiHookRunner implements
+	ManageWikiAfterSidebarLinksHook,
 	ManageWikiCoreAddFormFieldsHook,
 	ManageWikiCoreFormSubmissionHook
 {
@@ -14,6 +16,15 @@ class ManageWikiHookRunner implements
 	public function __construct(
 		private readonly HookContainer $container
 	) {
+	}
+
+	/** @inheritDoc */
+	public function onManageWikiAfterSidebarLinks( Skin $skin, array &$sidebar ): void {
+		$this->container->run(
+			'ManageWikiAfterSidebarLinks',
+			[ $skin, &$sidebar ],
+			[ 'abortable' => false ]
+		);
 	}
 
 	/** @inheritDoc */


### PR DESCRIPTION
Needed for DataDump to be able to add the sidebar link for it since the order was changed when this was moved to HookHandlers, so the hooks in ManageWiki are loaded after DataDump causing a race condition, and it not adding a link there. It could also have other benefits as well.