### PR TITLE
Use wiki group

### DIFF
--- a/includes/Specials/SpecialManageWikiDefaults.php
+++ b/includes/Specials/SpecialManageWikiDefaults.php
@@ -331,7 +331,7 @@ class SpecialManageWikiDefaults extends SpecialPage {
 
 	/** @inheritDoc */
 	protected function getGroupName(): string {
-		return 'wikimanage';
+		return 'wiki';
 	}
 
 	/** @inheritDoc */


### PR DESCRIPTION
Factoring out wikimanage because that means extensions rely on MirahezeMagic for the i18n and we dont want to copy rhe i18n to numerous extensions.