### PR TITLE
Fix race condition when running multiple scripts

### DIFF
--- a/includes/Helpers/ManageWikiInstaller.php
+++ b/includes/Helpers/ManageWikiInstaller.php
@@ -131,21 +131,18 @@ class ManageWikiInstaller {
 			throw new RuntimeException( 'Shell is disabled.' );
 		}
 
-		foreach ( $data as $script => $options ) {
-			$jobQueueGroupFactory = MediaWikiServices::getInstance()->getJobQueueGroupFactory();
-			$jobQueueGroup = $jobQueueGroupFactory->makeJobQueueGroup();
+		$jobQueueGroupFactory = MediaWikiServices::getInstance()->getJobQueueGroupFactory();
+		$jobQueueGroup = $jobQueueGroupFactory->makeJobQueueGroup();
 
-			$jobQueueGroup->push(
-				new JobSpecification(
-					MWScriptJob::JOB_NAME,
-					[
-						'dbname' => $dbname,
-						'script' => $script,
-						'options' => $options,
-					]
-				)
-			);
-		}
+		$jobQueueGroup->push(
+			new JobSpecification(
+				MWScriptJob::JOB_NAME,
+				[
+					'data' => $data,
+					'dbname' => $dbname,
+				]
+			)
+		);
 
 		return true;
 	}

--- a/includes/Jobs/MWScriptJob.php
+++ b/includes/Jobs/MWScriptJob.php
@@ -31,8 +31,8 @@ class MWScriptJob extends Job {
 	 */
 	public function run(): bool {
 		$limits = [ 'memory' => 0, 'filesize' => 0 ];
-		$arguments = [ '--wiki', $this->dbname ];
 		foreach ( $this->data as $script => $options ) {
+			$arguments = [ '--wiki', $this->dbname ];
 			$repeatWith = [];
 			if ( isset( $options['repeat-with'] ) ) {
 				$repeatWith = $options['repeat-with'];

--- a/includes/Jobs/MWScriptJob.php
+++ b/includes/Jobs/MWScriptJob.php
@@ -12,10 +12,8 @@ class MWScriptJob extends Job {
 
 	public const JOB_NAME = 'MWScriptJob';
 
+	private readonly array $data;
 	private readonly string $dbname;
-	private readonly string $script;
-
-	private readonly array $options;
 
 	public function __construct(
 		array $params,
@@ -24,61 +22,59 @@ class MWScriptJob extends Job {
 	) {
 		parent::__construct( self::JOB_NAME, $params );
 
+		$this->data = $params['data'];
 		$this->dbname = $params['dbname'];
-		$this->options = $params['options'];
-		$this->script = $params['script'];
 	}
 
 	/**
 	 * @return bool
 	 */
 	public function run(): bool {
-		$repeatWith = [];
-		$options = $this->options;
-		if ( isset( $options['repeat-with'] ) ) {
-			$repeatWith = $options['repeat-with'];
-			unset( $options['repeat-with'] );
-		}
-
 		$limits = [ 'memory' => 0, 'filesize' => 0 ];
 		$arguments = [ '--wiki', $this->dbname ];
-
-		foreach ( $options as $name => $val ) {
-			$arguments[] = "--$name";
-
-			if ( !is_bool( $val ) ) {
-				$arguments[] = $val;
+		foreach ( $this->data as $script => $options ) {
+			$repeatWith = [];
+			if ( isset( $options['repeat-with'] ) ) {
+				$repeatWith = $options['repeat-with'];
+				unset( $options['repeat-with'] );
 			}
+
+			foreach ( $options as $name => $val ) {
+				$arguments[] = "--$name";
+
+				if ( !is_bool( $val ) ) {
+					$arguments[] = $val;
+				}
+			}
+
+			$result = Shell::makeScriptCommand( $script, $arguments )
+				->limits( $limits )
+				->execute()
+				->getExitCode();
+
+			// An execute code higher then 0 indicates failure.
+			if ( $result !== 0 ) {
+				$this->logger->error( 'MWScriptJob failure. Status {result} running {script}', [
+					'arguments' => json_encode( $arguments ),
+					'result' => $result,
+					'script' => $script,
+				] );
+			}
+
+			if ( $repeatWith ) {
+				$jobQueueGroup = $this->jobQueueGroupFactory->makeJobQueueGroup();
+				$jobQueueGroup->push(
+					new JobSpecification(
+						self::JOB_NAME,
+						[
+							'data' => [ $script => $repeatWith ],
+							'dbname' => $this->dbname,
+						]
+					)
+				);
+			}
+
+			return true;
 		}
-
-		$result = Shell::makeScriptCommand( $this->script, $arguments )
-			->limits( $limits )
-			->execute()
-			->getExitCode();
-
-		// An execute code higher then 0 indicates failure.
-		if ( $result !== 0 ) {
-			$this->logger->error( 'MWScriptJob failure. Status {result} running {script}', [
-				'arguments' => json_encode( $arguments ),
-				'result' => $result,
-				'script' => $this->script,
-			] );
-		}
-
-		if ( $repeatWith ) {
-			$jobQueueGroup = $this->jobQueueGroupFactory->makeJobQueueGroup();
-			$jobQueueGroup->push(
-				new JobSpecification(
-					self::JOB_NAME,
-					[
-						'dbname' => $this->dbname,
-						'script' => $this->script,
-						'options' => $repeatWith,
-					]
-				)
-			);
-		}
-
-		return true;
 	}
 }

--- a/includes/Jobs/MWScriptJob.php
+++ b/includes/Jobs/MWScriptJob.php
@@ -73,8 +73,8 @@ class MWScriptJob extends Job {
 					)
 				);
 			}
-
-			return true;
 		}
+
+		return true;
 	}
 }


### PR DESCRIPTION
Sometimes causes Jobs like CirrusSearch to fail "index(es) do not exist. Did you forget to run updateSearchIndexConfig?" when running ForceSearchIndex in same install step when it relies on the order that needs to ensure UpdateSearchIndexConfig runs first.