### PR TITLE
Use error log

### DIFF
--- a/includes/Hooks/Handlers/CreateWiki.php
+++ b/includes/Hooks/Handlers/CreateWiki.php
@@ -146,7 +146,7 @@ class CreateWiki implements
 					$lcEN = $this->localisationCache->getItem( 'en', 'namespaceNames' );
 				}
 			} catch ( Exception $e ) {
-				$this->logger->warning( 'Caught exception trying to load Localisation Cache: {exception}', [
+				$this->logger->error( 'Caught exception trying to load Localisation Cache: {exception}', [
 					'exception' => $e,
 				] );
 			}


### PR DESCRIPTION
When we are catching an exception to log it's an error not a warning