### PR TITLE
ToggleExtension: warn when disable not possible

### DIFF
--- a/maintenance/ToggleExtension.php
+++ b/maintenance/ToggleExtension.php
@@ -65,6 +65,7 @@ class ToggleExtension extends Maintenance {
 					$this->output( "Enabled $name on $dbname.\n" );
 				}
 			}
+			
 			if ( !in_array( $name, $extList, true ) && $disable && !$allWikis ) {
 				$this->fatalError( "Failed to disable $name on $dbname: Was it enabled?" );
 			}

--- a/maintenance/ToggleExtension.php
+++ b/maintenance/ToggleExtension.php
@@ -65,6 +65,9 @@ class ToggleExtension extends Maintenance {
 					$this->output( "Enabled $name on $dbname.\n" );
 				}
 			}
+			if ( !in_array( $name, $extList, true ) && $disable && !$allWikis) {
+				$this->output( "Failed to disable $name on $dbname.\n: Was it enabled?" );
+			}
 		}
 
 		if ( $noList && count( $dbnames ) > 1 ) {

--- a/maintenance/ToggleExtension.php
+++ b/maintenance/ToggleExtension.php
@@ -66,7 +66,7 @@ class ToggleExtension extends Maintenance {
 				}
 			}
 			if ( !in_array( $name, $extList, true ) && $disable && !$allWikis ) {
-				$this->output( "Failed to disable $name on $dbname: Was it enabled?\n" );
+				$this->fatalError( "Failed to disable $name on $dbname: Was it enabled?" );
 			}
 		}
 

--- a/maintenance/ToggleExtension.php
+++ b/maintenance/ToggleExtension.php
@@ -65,7 +65,7 @@ class ToggleExtension extends Maintenance {
 					$this->output( "Enabled $name on $dbname.\n" );
 				}
 			}
-			if ( !in_array( $name, $extList, true ) && $disable && !$allWikis) {
+			if ( !in_array( $name, $extList, true ) && $disable && !$allWikis ) {
 				$this->output( "Failed to disable $name on $dbname.\n: Was it enabled?" );
 			}
 		}

--- a/maintenance/ToggleExtension.php
+++ b/maintenance/ToggleExtension.php
@@ -65,7 +65,7 @@ class ToggleExtension extends Maintenance {
 					$this->output( "Enabled $name on $dbname.\n" );
 				}
 			}
-			
+
 			if ( !in_array( $name, $extList, true ) && $disable && !$allWikis ) {
 				$this->fatalError( "Failed to disable $name on $dbname: Was it enabled?" );
 			}

--- a/maintenance/ToggleExtension.php
+++ b/maintenance/ToggleExtension.php
@@ -66,7 +66,7 @@ class ToggleExtension extends Maintenance {
 				}
 			}
 			if ( !in_array( $name, $extList, true ) && $disable && !$allWikis ) {
-				$this->output( "Failed to disable $name on $dbname.\n: Was it enabled?" );
+				$this->output( "Failed to disable $name on $dbname: Was it enabled?\n" );
 			}
 		}
 


### PR DESCRIPTION
Avoid there being no output when nothing happens as --name is not validated against ManageWiki config anywhere

Don't show when --all-wikis passed to avoid spam