### PR TITLE
Add Rest API to delete and reset cache

### DIFF
--- a/includes/ConfigNames.php
+++ b/includes/ConfigNames.php
@@ -13,6 +13,8 @@ class ConfigNames {
 
 	public const CacheType = 'ManageWikiCacheType';
 
+	public const CacheUpdateKey = 'ManageWikiCacheUpdateKey';
+
 	public const Extensions = 'ManageWikiExtensions';
 
 	public const ExtensionsDefault = 'ManageWikiExtensionsDefault';

--- a/includes/Helpers/CacheUpdate.php
+++ b/includes/Helpers/CacheUpdate.php
@@ -52,19 +52,19 @@ class CacheUpdate {
 			: $urlInfo['host'];
 
 		$baseReq = [
-			'method' => 'PURGE',
-			'url' => $url,
+			'method' => 'POST',
 			'headers' => [
 				'Host' => $urlHost,
 				'Connection' => 'Keep-Alive',
-				'Proxy-Connection' => 'Keep-Alive',
 				'User-Agent' => 'ManageWiki extension',
 			],
 		];
 
+		$restPath = 'TODO';
+
 		$reqs = [];
 		foreach ( $servers as $server ) {
-			$reqs[] = ( $baseReq + [ 'proxy' => $server ] );
+			$reqs[] = ( $baseReq + [ 'url' => $server . $restPath ] );
 		}
 
 		$http = $this->httpRequestFactory->createMultiClient( [

--- a/includes/Helpers/DataStore.php
+++ b/includes/Helpers/DataStore.php
@@ -96,19 +96,18 @@ class DataStore {
 	 * Retrieves new information for the wiki and updates the cache.
 	 */
 	public function resetWikiData( bool $isNewChanges ): void {
-		$mtime = time();
 		if ( $isNewChanges ) {
-			$this->timestamp = $mtime;
+			$this->timestamp = time();
 			$this->cache->set(
 				$this->cache->makeGlobalKey( self::CACHE_KEY, $this->dbname ),
-				$mtime
+				$this->timestamp
 			);
 
 			$this->cacheUpdate->addUpdate();
 		}
 
 		$cacheArray = [
-			'mtime' => $mtime,
+			'mtime' => $this->timestamp,
 			'database' => $this->dbname,
 		];
 

--- a/includes/Rest/DeleteCacheHandler.php
+++ b/includes/Rest/DeleteCacheHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Miraheze\CreateWiki\RequestWiki\Rest;
+namespace Miraheze\ManageWiki\RequestWiki\Rest;
 
 use MediaWiki\Config\Config;
 use MediaWiki\Rest\Response;

--- a/includes/Rest/DeleteCacheHandler.php
+++ b/includes/Rest/DeleteCacheHandler.php
@@ -9,6 +9,8 @@ use Miraheze\ManageWiki\ConfigNames;
 use SensitiveParameter;
 use Wikimedia\Message\MessageValue;
 use Wikimedia\ParamValidator\ParamValidator;
+use function file_exists;
+use function unlink;
 
 class DeleteCacheHandler extends SimpleHandler {
 

--- a/includes/Rest/DeleteCacheHandler.php
+++ b/includes/Rest/DeleteCacheHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Miraheze\CreateWiki\RequestWiki\Rest;
+
+use MediaWiki\Config\Config;
+use MediaWiki\Rest\Response;
+use MediaWiki\Rest\SimpleHandler;
+use Miraheze\ManageWiki\ConfigNames;
+use SensitiveParameter;
+use Wikimedia\Message\MessageValue;
+use Wikimedia\ParamValidator\ParamValidator;
+
+class DeleteCacheHandler extends SimpleHandler {
+
+	public function __construct( private readonly Config $config ) {
+	}
+
+	public function run(
+		string $dbname,
+		#[SensitiveParameter]
+		string $key
+	): Response {
+		if ( $key !== $this->config->get( ConfigNames::CacheUpdateKey ) ) {
+			return $this->getResponseFactory()->createLocalizedHttpError(
+				403, new MessageValue( 'managewiki-rest-invalidkey' )
+			);
+		}
+
+		$this->config->get( ConfigNames::CacheDirectory )
+		if ( file_exists( "$cacheDir/$dbname.php" ) ) {
+			unlink( "$cacheDir/$dbname.php" );
+		}
+
+		return $this->getResponseFactory()->createNoContent();
+	}
+
+	public function needsWriteAccess(): bool {
+		return true;
+	}
+
+	public function getParamSettings(): array {
+		return [
+			'dbname' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => true,
+			],
+			'key' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => true,
+			],
+		];
+	}
+}

--- a/includes/Rest/DeleteCacheHandler.php
+++ b/includes/Rest/DeleteCacheHandler.php
@@ -28,7 +28,7 @@ class DeleteCacheHandler extends SimpleHandler {
 			);
 		}
 
-		$this->config->get( ConfigNames::CacheDirectory )
+		$cacheDir = $this->config->get( ConfigNames::CacheDirectory );
 		if ( file_exists( "$cacheDir/$dbname.php" ) ) {
 			unlink( "$cacheDir/$dbname.php" );
 		}

--- a/includes/Rest/DeleteCacheHandler.php
+++ b/includes/Rest/DeleteCacheHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Miraheze\ManageWiki\RequestWiki\Rest;
+namespace Miraheze\ManageWiki\Rest;
 
 use MediaWiki\Config\Config;
 use MediaWiki\Rest\Response;

--- a/includes/Rest/ResetCacheHandler.php
+++ b/includes/Rest/ResetCacheHandler.php
@@ -11,7 +11,7 @@ use SensitiveParameter;
 use Wikimedia\Message\MessageValue;
 use Wikimedia\ParamValidator\ParamValidator;
 
-class ResetWikiCacheHandler extends SimpleHandler {
+class ResetCacheHandler extends SimpleHandler {
 
 	public function __construct(
 		private readonly DataStoreFactory $dataStoreFactory,

--- a/includes/Rest/ResetCacheHandler.php
+++ b/includes/Rest/ResetCacheHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Miraheze\CreateWiki\RequestWiki\Rest;
+namespace Miraheze\ManageWiki\Rest;
 
 use MediaWiki\Config\Config;
 use MediaWiki\Rest\Response;

--- a/includes/Rest/ResetWikiCacheHandler.php
+++ b/includes/Rest/ResetWikiCacheHandler.php
@@ -9,7 +9,6 @@ use Miraheze\ManageWiki\Helpers\Factories\DataStoreFactory;
 use SensitiveParameter
 use Wikimedia\Message\MessageValue;
 use Wikimedia\ParamValidator\ParamValidator;
-use function ctype_space;
 
 class ResetWikiCacheHandler extends SimpleHandler {
 

--- a/includes/Rest/ResetWikiCacheHandler.php
+++ b/includes/Rest/ResetWikiCacheHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Miraheze\CreateWiki\RequestWiki\Rest;
+
+use MediaWiki\Rest\Response;
+use MediaWiki\Rest\SimpleHandler;
+use Miraheze\ManageWiki\ConfigNames;
+use Miraheze\ManageWiki\Helpers\Factories\DataStoreFactory;
+use SensitiveParameter
+use Wikimedia\Message\MessageValue;
+use Wikimedia\ParamValidator\ParamValidator;
+use function ctype_space;
+
+class ResetWikiCacheHandler extends SimpleHandler {
+
+	public function __construct(
+		private readonly DataStoreFactory $dataStoreFactory
+	) {
+	}
+
+	public function run(
+		string $dbname,
+		#[SensitiveParameter]
+		string $key
+	): Response {
+		if ( $key !== $this->getConfig()->get( ConfigNames::CacheUpdateKey ) ) {
+			return $this->getResponseFactory()->createLocalizedHttpError(
+				403, new MessageValue( 'managewiki-rest-invalidkey' )
+			);
+		}
+
+		$dataStore = $this->dataStoreFactory->newInstance( $dbname );
+		$dataStore->resetWikiData( isNewChanges: true );
+		return $this->getResponseFactory()->createNoContent();
+	}
+
+	public function needsWriteAccess(): bool {
+		return true;
+	}
+
+	public function getParamSettings(): array {
+		return [
+			'dbname' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => true,
+			],
+			'key' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => true,
+			],
+		];
+	}
+}

--- a/includes/Rest/ResetWikiCacheHandler.php
+++ b/includes/Rest/ResetWikiCacheHandler.php
@@ -7,7 +7,7 @@ use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
 use Miraheze\ManageWiki\ConfigNames;
 use Miraheze\ManageWiki\Helpers\Factories\DataStoreFactory;
-use SensitiveParameter
+use SensitiveParameter;
 use Wikimedia\Message\MessageValue;
 use Wikimedia\ParamValidator\ParamValidator;
 

--- a/includes/Rest/ResetWikiCacheHandler.php
+++ b/includes/Rest/ResetWikiCacheHandler.php
@@ -31,7 +31,7 @@ class ResetWikiCacheHandler extends SimpleHandler {
 		}
 
 		$dataStore = $this->dataStoreFactory->newInstance( $dbname );
-		$dataStore->resetWikiData( isNewChanges: true );
+		$dataStore->resetWikiData( isNewChanges: false );
 		return $this->getResponseFactory()->createNoContent();
 	}
 

--- a/includes/Rest/ResetWikiCacheHandler.php
+++ b/includes/Rest/ResetWikiCacheHandler.php
@@ -2,6 +2,7 @@
 
 namespace Miraheze\CreateWiki\RequestWiki\Rest;
 
+use MediaWiki\Config\Config;
 use MediaWiki\Rest\Response;
 use MediaWiki\Rest\SimpleHandler;
 use Miraheze\ManageWiki\ConfigNames;
@@ -13,7 +14,8 @@ use Wikimedia\ParamValidator\ParamValidator;
 class ResetWikiCacheHandler extends SimpleHandler {
 
 	public function __construct(
-		private readonly DataStoreFactory $dataStoreFactory
+		private readonly DataStoreFactory $dataStoreFactory,
+		private readonly Config $config
 	) {
 	}
 
@@ -22,7 +24,7 @@ class ResetWikiCacheHandler extends SimpleHandler {
 		#[SensitiveParameter]
 		string $key
 	): Response {
-		if ( $key !== $this->getConfig()->get( ConfigNames::CacheUpdateKey ) ) {
+		if ( $key !== $this->config->get( ConfigNames::CacheUpdateKey ) ) {
 			return $this->getResponseFactory()->createLocalizedHttpError(
 				403, new MessageValue( 'managewiki-rest-invalidkey' )
 			);


### PR DESCRIPTION
These are protected behind a key to make them work only internally. The idea here is to be able to run update and delete cache across all servers using the CacheUpdate service.

<!--
Test with:
```php
MediaWiki\MediaWikiServices::getInstance()->get( 'ManageWikiCacheUpdate' )->doUpdate()
```
-->