### PR TITLE
Revert "MWScriptJob: make sure cache is up-to-date before running anything"

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -39,7 +39,6 @@
 			"class": "Miraheze\\ManageWiki\\Jobs\\MWScriptJob",
 			"services": [
 				"JobQueueGroupFactory",
-				"ManageWikiDataStoreFactory",
 				"ManageWikiLogger"
 			],
 			"needsPage": false

--- a/includes/Jobs/MWScriptJob.php
+++ b/includes/Jobs/MWScriptJob.php
@@ -41,7 +41,6 @@ class MWScriptJob extends Job {
 
 			foreach ( $options as $name => $val ) {
 				$arguments[] = "--$name";
-
 				if ( !is_bool( $val ) ) {
 					$arguments[] = $val;
 				}

--- a/includes/Jobs/MWScriptJob.php
+++ b/includes/Jobs/MWScriptJob.php
@@ -6,7 +6,6 @@ use MediaWiki\JobQueue\Job;
 use MediaWiki\JobQueue\JobQueueGroupFactory;
 use MediaWiki\JobQueue\JobSpecification;
 use MediaWiki\Shell\Shell;
-use Miraheze\ManageWiki\Helpers\Factories\DataStoreFactory;
 use Psr\Log\LoggerInterface;
 use function is_bool;
 use function json_encode;
@@ -21,7 +20,6 @@ class MWScriptJob extends Job {
 	public function __construct(
 		array $params,
 		private readonly JobQueueGroupFactory $jobQueueGroupFactory,
-		private readonly DataStoreFactory $dataStoreFactory,
 		private readonly LoggerInterface $logger,
 	) {
 		parent::__construct( self::JOB_NAME, $params );
@@ -32,10 +30,6 @@ class MWScriptJob extends Job {
 
 	/** @inheritDoc */
 	public function run(): true {
-		// Make sure cache is up-to-date before running anything.
-		$dataStore = $this->dataStoreFactory->newInstance( $this->dbname );
-		$dataStore->syncCache();
-
 		$limits = [ 'memory' => 0, 'filesize' => 0 ];
 		foreach ( $this->data as $script => $options ) {
 			$arguments = [ '--wiki', $this->dbname ];
@@ -47,6 +41,7 @@ class MWScriptJob extends Job {
 
 			foreach ( $options as $name => $val ) {
 				$arguments[] = "--$name";
+
 				if ( !is_bool( $val ) ) {
 					$arguments[] = $val;
 				}


### PR DESCRIPTION
Reverts miraheze/ManageWiki#777

This is basically a no-op because the cache is invalidated in SetupAfterCache anyway, and resetting the cache during a request doesn't make a difference for the current request because the loaded extensions and settings will still be the ones that were listed in the old cache entry.