### PR TITLE
Add codex icons to managewiki tabs for Citizen to avoid blank buttons

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -181,6 +181,9 @@
 		},
 		"SidebarBeforeOutput": {
 			"handler": "Main"
+		},
+		"SkinTemplateNavigation::Universal": {
+			"handler": "Main"
 		}
 	},
 	"HookHandlers": {

--- a/includes/Hooks/Handlers/Main.php
+++ b/includes/Hooks/Handlers/Main.php
@@ -7,8 +7,10 @@ use MediaWiki\Content\FallbackContentHandler;
 use MediaWiki\Content\Hook\ContentHandlerForModelIDHook;
 use MediaWiki\Hook\SetupAfterCacheHook;
 use MediaWiki\Hook\SidebarBeforeOutputHook;
+use MediaWiki\Hook\SkinTemplateNavigation__UniversalHook;
 use MediaWiki\MainConfigNames;
 use MediaWiki\Preferences\Hook\GetPreferencesHook;
+use MediaWiki\Skin\SkinTemplate;
 use MediaWiki\SpecialPage\SpecialPage;
 use MediaWiki\User\Options\UserOptionsLookup;
 use MediaWiki\User\User;
@@ -23,8 +25,17 @@ class Main implements
 	ContentHandlerForModelIDHook,
 	GetPreferencesHook,
 	SetupAfterCacheHook,
-	SidebarBeforeOutputHook
+	SidebarBeforeOutputHook,
+	SkinTemplateNavigation__UniversalHook
 {
+
+	private const MODULE_ICONS = [
+		'core' => 'labFlask',
+		'extensions' => 'edit',
+		'namespaces' => 'listBullet',
+		'permissions' => 'userGroup',
+		'settings' => 'settings',
+	];
 
 	public function __construct(
 		private readonly Config $config,
@@ -98,6 +109,27 @@ class Main implements
 			$sidebarLinks = $sidebar['managewiki-sidebar-header'];
 			$this->hookRunner->onManageWikiAfterSidebarLinks( $skin, $sidebarLinks );
 			$sidebar['managewiki-sidebar-header'] = $sidebarLinks;
+		}
+	}
+
+	/** @inheritDoc */
+	public function onSkinTemplateNavigation__Universal( $sktemplate, &$links ): void {
+        // only on citizen
+		if ( $sktemplate->getSkinName() !== 'citizen' ) {
+			return;
+		}
+
+		if ( !isset( $links['associated-pages'] ) || $links['associated-pages'] === [] ) {
+			return;
+		}
+
+		foreach ( self::MODULE_ICONS as $module => $icon ) {
+			$href = SpecialPage::getTitleFor( 'ManageWiki', $module )->getLocalURL();
+			foreach ( $links['associated-pages'] as $key => $link ) {
+				if ( ( $link['href'] ?? null ) === $href ) {
+					$links['associated-pages'][$key]['icon'] ??= $icon;
+				}
+			}
 		}
 	}
 }

--- a/includes/Hooks/Handlers/Main.php
+++ b/includes/Hooks/Handlers/Main.php
@@ -29,7 +29,7 @@ class Main implements
 	SkinTemplateNavigation__UniversalHook
 {
 
-	private const MODULE_ICONS = [
+	private const array MODULE_ICONS = [
 		'core' => 'labFlask',
 		'extensions' => 'edit',
 		'namespaces' => 'listBullet',
@@ -112,14 +112,14 @@ class Main implements
 		}
 	}
 
-	/** @inheritDoc */
+    /**
+     * @inheritDoc
+     * @phpcs:disable MediaWiki.NamingConventions.LowerCamelFunctionsName.FunctionName
+     */
 	public function onSkinTemplateNavigation__Universal( $sktemplate, &$links ): void {
-        // only on citizen
-		if ( $sktemplate->getSkinName() !== 'citizen' ) {
-			return;
-		}
+        // phpcs:enable MediaWiki.NamingConventions.LowerCamelFunctionsName.FunctionName
 
-		if ( !isset( $links['associated-pages'] ) || $links['associated-pages'] === [] ) {
+        if ( empty( $links['associated-pages'] ) ) {
 			return;
 		}
 


### PR DESCRIPTION
On citizen (in particular mobile/small screens), the tabs show at the bottom with no icons
<img width="167" height="56" alt="image" src="https://github.com/user-attachments/assets/7c2f0ba0-f244-4fd9-919f-f169f4acf2da" /> and can't really be distinguished other than by the order, this should add icons (albeit not great ones as citizen has a limited set of icons it loads) so it is slightly more user friendly
